### PR TITLE
Add Create Model Form

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,18 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.49.2",
     "react-router-dom": "^6.21.0",
+    "react-spinners": "^0.13.8",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.6",
-    "zod": "^3.22.4"
+    "uuid": "^9.0.1",
+    "zod": "^3.22.4",
+    "zustand": "^4.4.7"
   },
   "devDependencies": {
     "@types/node": "^20.10.4",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
+    "@types/uuid": "^9.0.7",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^6.14.0",
     "@vitejs/plugin-react": "^4.0.3",

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -5,6 +5,7 @@ export * from './divider';
 export * from './dropdown';
 export * from './input';
 export * from './notification';
+export * from './select';
 export * from './status-icon';
 export * from './table';
 export * from './text-area';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -4,6 +4,7 @@ export * from './button';
 export * from './divider';
 export * from './dropdown';
 export * from './input';
+export * from './label';
 export * from './notification';
 export * from './select';
 export * from './status-icon';

--- a/src/components/ui/input/Input.tsx
+++ b/src/components/ui/input/Input.tsx
@@ -1,6 +1,8 @@
-import { cn } from '@/lib/cn';
+import { forwardRef } from 'react';
 import { ExclamationCircleIcon } from '@heroicons/react/20/solid';
 import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/cn';
 
 const inputVariants = cva(
     'block w-full rounded-md border-0 px-3 py-1.5 ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500 disabled:ring-gray-200',
@@ -21,15 +23,22 @@ const inputVariants = cva(
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement> &
     VariantProps<typeof inputVariants>;
 
-export const Input = ({ className, variant, ...props }: InputProps) => {
-    return (
-        <>
-            <input className={cn(inputVariants({ variant, className }))} {...props} />
-            {variant === 'error' ? (
-                <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3'>
-                    <ExclamationCircleIcon className='h-5 w-5 text-red-500' aria-hidden='true' />
-                </div>
-            ) : null}
-        </>
-    );
-};
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+    ({ className, variant, ...props }, ref) => {
+        return (
+            <>
+                <input className={cn(inputVariants({ variant, className }))} ref={ref} {...props} />
+                {variant === 'error' ? (
+                    <div className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3'>
+                        <ExclamationCircleIcon
+                            className='h-5 w-5 text-red-500'
+                            aria-hidden='true'
+                        />
+                    </div>
+                ) : null}
+            </>
+        );
+    },
+);
+
+Input.displayName = 'Input';

--- a/src/components/ui/label/Label.tsx
+++ b/src/components/ui/label/Label.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/lib/cn';
+
+export type LabelProps = {
+    children: React.ReactNode;
+} & React.LabelHTMLAttributes<HTMLLabelElement>;
+
+export const Label = ({ children, className, ...props }: LabelProps) => {
+    return (
+        <label
+            className={cn('block text-sm font-medium leading-6 text-gray-900', className)}
+            {...props}
+        >
+            {children}
+        </label>
+    );
+};

--- a/src/components/ui/label/index.ts
+++ b/src/components/ui/label/index.ts
@@ -1,0 +1,1 @@
+export * from './Label';

--- a/src/components/ui/select/Select.tsx
+++ b/src/components/ui/select/Select.tsx
@@ -1,19 +1,26 @@
+import { forwardRef } from 'react';
+
 import { cn } from '@/lib/cn';
 
 export type SelectProps = {
     children: React.ReactNode;
 } & React.SelectHTMLAttributes<HTMLSelectElement>;
 
-export const Select = ({ children, className, ...props }: SelectProps) => {
-    return (
-        <select
-            className={cn(
-                'block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6',
-                className,
-            )}
-            {...props}
-        >
-            {children}
-        </select>
-    );
-};
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+    ({ children, className, ...props }, ref) => {
+        return (
+            <select
+                className={cn(
+                    'block w-full rounded-md border-0 px-3 py-2 ring-1 ring-inset text-gray-900 shadow-sm ring-gray-300 focus:ring-indigo-600 focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6',
+                    className,
+                )}
+                ref={ref}
+                {...props}
+            >
+                {children}
+            </select>
+        );
+    },
+);
+
+Select.displayName = 'Select';

--- a/src/components/ui/select/Select.tsx
+++ b/src/components/ui/select/Select.tsx
@@ -1,40 +1,19 @@
-import React, { Fragment } from 'react';
-import { Listbox, Transition } from '@headlessui/react';
-import { ChevronUpDownIcon } from '@heroicons/react/20/solid';
+import { cn } from '@/lib/cn';
 
 export type SelectProps = {
     children: React.ReactNode;
-    onChange: React.Dispatch<React.SetStateAction<string>>;
-    value: string;
-};
+} & React.SelectHTMLAttributes<HTMLSelectElement>;
 
-export const Select = ({ children, onChange, value }: SelectProps) => {
+export const Select = ({ children, className, ...props }: SelectProps) => {
     return (
-        <Listbox value={value} onChange={onChange}>
-            {({ open }) => (
-                <>
-                    <div className='relative'>
-                        <Listbox.Button className='relative w-full cursor-default rounded-md bg-white py-1.5 pl-3 pr-10 text-left text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6'>
-                            <span className='block truncate'>{value}</span>
-                            <span className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2'>
-                                <ChevronUpDownIcon className='h-5 w-5 text-gray-400' />
-                            </span>
-                        </Listbox.Button>
-
-                        <Transition
-                            show={open}
-                            as={Fragment}
-                            leave='transition ease-in duration-100'
-                            leaveFrom='opacity-100'
-                            leaveTo='opacity-0'
-                        >
-                            <Listbox.Options className='absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm'>
-                                {children}
-                            </Listbox.Options>
-                        </Transition>
-                    </div>
-                </>
+        <select
+            className={cn(
+                'block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6',
+                className,
             )}
-        </Listbox>
+            {...props}
+        >
+            {children}
+        </select>
     );
 };

--- a/src/components/ui/select/Select.tsx
+++ b/src/components/ui/select/Select.tsx
@@ -1,0 +1,40 @@
+import React, { Fragment } from 'react';
+import { Listbox, Transition } from '@headlessui/react';
+import { ChevronUpDownIcon } from '@heroicons/react/20/solid';
+
+export type SelectProps = {
+    children: React.ReactNode;
+    onChange: React.Dispatch<React.SetStateAction<string>>;
+    value: string;
+};
+
+export const Select = ({ children, onChange, value }: SelectProps) => {
+    return (
+        <Listbox value={value} onChange={onChange}>
+            {({ open }) => (
+                <>
+                    <div className='relative'>
+                        <Listbox.Button className='relative w-full cursor-default rounded-md bg-white py-1.5 pl-3 pr-10 text-left text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6'>
+                            <span className='block truncate'>{value}</span>
+                            <span className='pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2'>
+                                <ChevronUpDownIcon className='h-5 w-5 text-gray-400' />
+                            </span>
+                        </Listbox.Button>
+
+                        <Transition
+                            show={open}
+                            as={Fragment}
+                            leave='transition ease-in duration-100'
+                            leaveFrom='opacity-100'
+                            leaveTo='opacity-0'
+                        >
+                            <Listbox.Options className='absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm'>
+                                {children}
+                            </Listbox.Options>
+                        </Transition>
+                    </div>
+                </>
+            )}
+        </Listbox>
+    );
+};

--- a/src/components/ui/select/SelectItem.tsx
+++ b/src/components/ui/select/SelectItem.tsx
@@ -1,0 +1,44 @@
+import { Listbox } from '@headlessui/react';
+
+import { cn } from '@/lib/cn';
+import { CheckIcon } from '@heroicons/react/20/solid';
+
+export type SelectItemProps = {
+    children: React.ReactNode;
+    value: string;
+};
+
+export const SelectItem = ({ children, value }: SelectItemProps) => {
+    return (
+        <Listbox.Option
+            className={({ active }) =>
+                cn(
+                    active ? 'bg-indigo-600 text-white' : 'text-gray-900',
+                    'relative cursor-default select-none py-2 pl-3 pr-9',
+                )
+            }
+            value={value}
+        >
+            {({ selected, active }) => (
+                <>
+                    <span
+                        className={cn(selected ? 'font-semibold' : 'font-normal', 'block truncate')}
+                    >
+                        {children}
+                    </span>
+
+                    {selected ? (
+                        <span
+                            className={cn(
+                                active ? 'text-white' : 'text-indigo-600',
+                                'absolute inset-y-0 right-0 flex items-center pr-4',
+                            )}
+                        >
+                            <CheckIcon className='h-5 w-5' />
+                        </span>
+                    ) : null}
+                </>
+            )}
+        </Listbox.Option>
+    );
+};

--- a/src/components/ui/select/SelectItem.tsx
+++ b/src/components/ui/select/SelectItem.tsx
@@ -1,44 +1,13 @@
-import { Listbox } from '@headlessui/react';
-
 import { cn } from '@/lib/cn';
-import { CheckIcon } from '@heroicons/react/20/solid';
 
 export type SelectItemProps = {
     children: React.ReactNode;
-    value: string;
-};
+} & React.OptionHTMLAttributes<HTMLOptionElement>;
 
-export const SelectItem = ({ children, value }: SelectItemProps) => {
+export const SelectItem = ({ children, className, ...props }: SelectItemProps) => {
     return (
-        <Listbox.Option
-            className={({ active }) =>
-                cn(
-                    active ? 'bg-indigo-600 text-white' : 'text-gray-900',
-                    'relative cursor-default select-none py-2 pl-3 pr-9',
-                )
-            }
-            value={value}
-        >
-            {({ selected, active }) => (
-                <>
-                    <span
-                        className={cn(selected ? 'font-semibold' : 'font-normal', 'block truncate')}
-                    >
-                        {children}
-                    </span>
-
-                    {selected ? (
-                        <span
-                            className={cn(
-                                active ? 'text-white' : 'text-indigo-600',
-                                'absolute inset-y-0 right-0 flex items-center pr-4',
-                            )}
-                        >
-                            <CheckIcon className='h-5 w-5' />
-                        </span>
-                    ) : null}
-                </>
-            )}
-        </Listbox.Option>
+        <option className={cn(className)} {...props}>
+            {children}
+        </option>
     );
 };

--- a/src/components/ui/select/index.ts
+++ b/src/components/ui/select/index.ts
@@ -1,0 +1,2 @@
+export * from './Select';
+export * from './SelectItem';

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, RouterProvider as Router } from 'react-router-dom'
 
 import { DashboardLayout } from '@/components/layout';
 import {
+    CreateModel,
     CreateModelVersion,
     Home,
     ModelRegistry,
@@ -28,6 +29,10 @@ export const RouterProvider = () => {
                 {
                     path: '/dashboard/models',
                     element: <ModelRegistry />,
+                },
+                {
+                    path: '/dashboard/models/create',
+                    element: <CreateModel />,
                 },
                 {
                     path: '/dashboard/models/:modelId',

--- a/src/routes/create-model/api/createModel.ts
+++ b/src/routes/create-model/api/createModel.ts
@@ -1,0 +1,13 @@
+import { useMutation, type TypedDocumentNode, gql } from '@apollo/client';
+
+import type { CreateMLModel } from '@/types/MLModel';
+
+const CREATE_MODEL: TypedDocumentNode<CreateMLModel> = gql`
+    mutation CreateModel($data: ModelInput!) {
+        createModel(data: $data) {
+            modelId
+        }
+    }
+`;
+
+export const useCreateModel = () => useMutation(CREATE_MODEL);

--- a/src/routes/create-model/api/index.ts
+++ b/src/routes/create-model/api/index.ts
@@ -1,0 +1,2 @@
+export * from './createModel';
+export * from './listStorageProviders';

--- a/src/routes/create-model/api/listStorageProviders.ts
+++ b/src/routes/create-model/api/listStorageProviders.ts
@@ -1,0 +1,14 @@
+import { gql, useQuery, type TypedDocumentNode } from '@apollo/client';
+
+import type { StorageProviderList } from '@/types/StorageProvider';
+
+const LIST_STORAGE_PROVIDERS: TypedDocumentNode<StorageProviderList> = gql`
+    query ListStorageProviders {
+        listStorageProviders {
+            providerId
+            bucket
+        }
+    }
+`;
+
+export const useListStorageProviders = () => useQuery(LIST_STORAGE_PROVIDERS);

--- a/src/routes/create-model/index.tsx
+++ b/src/routes/create-model/index.tsx
@@ -1,3 +1,54 @@
+import { useState } from 'react';
+
+import {
+    BreadcrumbItem,
+    Breadcrumbs,
+    Input,
+    Label,
+    Select,
+    SelectItem,
+    TextArea,
+} from '@/components/ui';
+
+const storageProviders = ['Storage Provider 1', 'Storage Provider 2'];
+
 export const CreateModel = () => {
-    return <div>Welcome to the create model page!</div>;
+    const [storageProvider, setStorageProvider] = useState(storageProviders[0]);
+
+    return (
+        <div className='w-full flex flex-col gap-12'>
+            <header className='flex flex-col gap-4'>
+                <div>
+                    <Breadcrumbs>
+                        <BreadcrumbItem href='/dashboard/home'>Dashboard</BreadcrumbItem>
+                        <BreadcrumbItem href='/dashboard/models'>Models</BreadcrumbItem>
+                        <BreadcrumbItem href='/dashboard/models/create'>Create</BreadcrumbItem>
+                    </Breadcrumbs>
+                </div>
+                <h2 className='text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight'>
+                    Register New Model
+                </h2>
+            </header>
+            <form className='grid grid-cols-1 gap-x-6 gap-y-8 items-center sm:grid-cols-4'>
+                <div className='flex flex-col gap-2 sm:col-span-2'>
+                    <Label>Storage Provider</Label>
+                    <Select value={storageProvider} onChange={setStorageProvider}>
+                        {storageProviders.map((storageProvider) => (
+                            <SelectItem key={storageProvider} value={storageProvider}>
+                                {storageProvider}
+                            </SelectItem>
+                        ))}
+                    </Select>
+                </div>
+                <div className='flex flex-col gap-2 sm:col-span-2'>
+                    <Label>Model Name</Label>
+                    <Input />
+                </div>
+                <div className='flex flex-col gap-2 sm:col-span-4'>
+                    <Label>Description</Label>
+                    <TextArea rows={4} />
+                </div>
+            </form>
+        </div>
+    );
 };

--- a/src/routes/create-model/index.tsx
+++ b/src/routes/create-model/index.tsx
@@ -1,0 +1,3 @@
+export const CreateModel = () => {
+    return <div>Welcome to the create model page!</div>;
+};

--- a/src/routes/create-model/index.tsx
+++ b/src/routes/create-model/index.tsx
@@ -1,8 +1,15 @@
-import { useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { BarLoader } from 'react-spinners';
+import { z } from 'zod';
+
+import { useNotificationStore } from '@/stores';
 
 import {
     BreadcrumbItem,
     Breadcrumbs,
+    Button,
     Input,
     Label,
     Select,
@@ -10,10 +17,59 @@ import {
     TextArea,
 } from '@/components/ui';
 
-const storageProviders = ['Storage Provider 1', 'Storage Provider 2'];
+import { useCreateModel, useListStorageProviders } from './api';
+
+const createModelInputSchema = z.object({
+    description: z.string().optional(),
+    modelName: z.string().min(1, 'Model Name is required.'),
+    storageProviderId: z.string().uuid(),
+});
+
+type CreateModelInput = z.infer<typeof createModelInputSchema>;
 
 export const CreateModel = () => {
-    const [storageProvider, setStorageProvider] = useState(storageProviders[0]);
+    const [createModel, { loading: createModelLoading }] = useCreateModel();
+    const {
+        data: storageProviders,
+        loading: storageProviderLoading,
+        error,
+    } = useListStorageProviders();
+
+    const { addNotification } = useNotificationStore();
+    const navigate = useNavigate();
+
+    const { register, handleSubmit } = useForm<CreateModelInput>({
+        resolver: zodResolver(createModelInputSchema),
+    });
+
+    const onSubmit: SubmitHandler<CreateModelInput> = (data) => {
+        createModel({
+            variables: {
+                data: {
+                    description: data.description,
+                    modelName: data.modelName,
+                    storageProviderId: data.storageProviderId,
+                },
+            },
+            onCompleted: () => navigate('/dashboard/models'),
+            onError: (error) =>
+                addNotification({
+                    type: 'error',
+                    title: 'Error',
+                    // TODO: Change this type to just be a string
+                    children: error.message,
+                }),
+        });
+    };
+
+    if (storageProviderLoading) {
+        return <BarLoader color='#4f46e5' width='250px' />;
+    }
+
+    // TODO: Change UX
+    if (error) {
+        return `Error! ${error.message}`;
+    }
 
     return (
         <div className='w-full flex flex-col gap-12'>
@@ -29,26 +85,50 @@ export const CreateModel = () => {
                     Register New Model
                 </h2>
             </header>
-            <form className='grid grid-cols-1 gap-x-6 gap-y-8 items-center sm:grid-cols-4'>
-                <div className='flex flex-col gap-2 sm:col-span-2'>
-                    <Label>Storage Provider</Label>
-                    <Select value={storageProvider} onChange={setStorageProvider}>
-                        {storageProviders.map((storageProvider) => (
-                            <SelectItem key={storageProvider} value={storageProvider}>
-                                {storageProvider}
-                            </SelectItem>
-                        ))}
-                    </Select>
-                </div>
-                <div className='flex flex-col gap-2 sm:col-span-2'>
-                    <Label>Model Name</Label>
-                    <Input />
-                </div>
-                <div className='flex flex-col gap-2 sm:col-span-4'>
-                    <Label>Description</Label>
-                    <TextArea rows={4} />
-                </div>
-            </form>
+            {!createModelLoading ? (
+                <form
+                    className='grid grid-cols-1 gap-x-6 gap-y-8 items-center sm:grid-cols-4'
+                    onSubmit={handleSubmit(onSubmit)}
+                >
+                    <div className='flex flex-col gap-2 sm:col-span-2'>
+                        <Label>Storage Provider</Label>
+                        <Select {...register('storageProviderId')}>
+                            {storageProviders &&
+                                storageProviders.listStorageProviders &&
+                                storageProviders.listStorageProviders.map((storageProvider) => (
+                                    <SelectItem
+                                        key={storageProvider.providerId}
+                                        value={storageProvider.providerId}
+                                    >
+                                        {storageProvider.bucket}
+                                    </SelectItem>
+                                ))}
+                        </Select>
+                    </div>
+                    <div className='flex flex-col gap-2 sm:col-span-2'>
+                        <Label>Model Name</Label>
+                        <Input {...register('modelName')} />
+                    </div>
+                    <div className='flex flex-col gap-2 sm:col-span-4'>
+                        <Label>Description</Label>
+                        <TextArea rows={4} {...register('description')} />
+                    </div>
+                    <div className='col-span-4 flex items-center justify-end gap-4'>
+                        <Button
+                            variant='secondary'
+                            size='lg'
+                            onClick={() => navigate(`/dashboard/models/`)}
+                        >
+                            Cancel
+                        </Button>
+                        <Button size='lg' type='submit'>
+                            Submit
+                        </Button>
+                    </div>
+                </form>
+            ) : (
+                <BarLoader color='#4f46e5' width='250px' />
+            )}
         </div>
     );
 };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,3 +1,4 @@
+export * from './create-model';
 export * from './create-model-version';
 export * from './home';
 export * from './model-registry';

--- a/src/routes/model-registry/index.tsx
+++ b/src/routes/model-registry/index.tsx
@@ -43,7 +43,9 @@ export const ModelRegistry = () => {
                     <h2 className='text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight'>
                         Model Registry
                     </h2>
-                    <Button size='lg'>Create</Button>
+                    <Button onClick={() => navigate('/dashboard/models/create')} size='lg'>
+                        Create
+                    </Button>
                 </div>
             </header>
             {/* TODO: Add in indicator that lets user know there are no models current registered */}

--- a/src/types/MLModel.ts
+++ b/src/types/MLModel.ts
@@ -18,3 +18,7 @@ export type MLModel = {
 export type MLModelList = {
     listMLModels: MLModel[];
 };
+
+export type CreateMLModel = {
+    createModel: MLModel;
+};

--- a/src/types/StorageProvider.ts
+++ b/src/types/StorageProvider.ts
@@ -12,3 +12,7 @@ export type StorageProvider = {
     dateModified: string;
     isArchvied: boolean;
 };
+
+export type StorageProviderList = {
+    listStorageProviders: StorageProvider[];
+};


### PR DESCRIPTION
Ref #3 

This adds the Create Model page. Users are able to select the storage provider, input the model name, and provide an optional description. The storage provider options come from the `listStorageProviders` query, and if an error occurs while retrieving those values, an error is displayed and the form is inaccessible.

Upon submission, if an error occurs then a notification is shown to the user w/ the error message. If successful, the user is brought back to the model registry page, where the new model will be displayed w/ a total versions of 0.

To get this to work I added in / tweaked the following:
  - Added a label component
  - Added a select component
  - Adjusted the input component to use the `forwardRef` property.

All other changes are just adding in the actual form submission page and the graphql methods.

![image](https://github.com/dstk-labs/dstk-web/assets/77359138/240cafca-69bc-494d-8d70-7185a10bf426)
