### PR TITLE
Add Model Versioning List

### DIFF
--- a/src/routes/model-version/api/index.ts
+++ b/src/routes/model-version/api/index.ts
@@ -1,0 +1,1 @@
+export * from './listModelVersions';

--- a/src/routes/model-version/api/listModelVersions.ts
+++ b/src/routes/model-version/api/listModelVersions.ts
@@ -1,0 +1,21 @@
+import { gql, useQuery, type TypedDocumentNode } from '@apollo/client';
+
+import type { MLModelVersionList } from '@/types/MLModelVersion';
+
+const LIST_MODEL_VERSIONS: TypedDocumentNode<MLModelVersionList> = gql`
+    query ListMLModelVersions($modelId: String!) {
+        listMLModelVersions(modelId: $modelId) {
+            createdBy
+            dateCreated
+            modelVersionId
+            numericVersion
+        }
+    }
+`;
+
+export const useListModelVersions = (modelId: string) =>
+    useQuery(LIST_MODEL_VERSIONS, {
+        variables: {
+            modelId: modelId,
+        },
+    });

--- a/src/routes/model-version/index.tsx
+++ b/src/routes/model-version/index.tsx
@@ -84,7 +84,7 @@ export const ModelVersion = () => {
                     </Button>
                 </div>
             </header>
-            <Table className='whitespace-nowrap overflow-x-scroll'>
+            <Table>
                 <TableHead>
                     <TableRow>
                         <TableHeaderCell>Version ID</TableHeaderCell>

--- a/src/routes/model-version/index.tsx
+++ b/src/routes/model-version/index.tsx
@@ -6,7 +6,6 @@ import { BarLoader } from 'react-spinners';
 import { useGetModel } from '@/hooks';
 
 import {
-    Badge,
     BreadcrumbItem,
     Breadcrumbs,
     Button,
@@ -16,47 +15,10 @@ import {
     TableHead,
     TableHeaderCell,
     TableRow,
-    type BadgeProps,
     Tooltip,
 } from '@/components/ui';
 
-const models = [
-    {
-        versionId: '78f33d7c-dbe5-45e0-a49c-c9c54706b6f0',
-        version: 5,
-        deploymentStatus: 'Pending',
-        createdBy: 'Steve O',
-        lastModified: 'December 12th, 2023',
-    },
-    {
-        versionId: '297e5931-c8d4-46a0-87ba-a210cdf8a9fd',
-        version: 4,
-        deploymentStatus: 'Active',
-        createdBy: 'Steve O',
-        lastModified: 'December 11th, 2023',
-    },
-    {
-        versionId: '5f636561-12ab-43ef-aa90-416d15d33006',
-        version: 3,
-        deploymentStatus: 'Active',
-        createdBy: 'Steve O',
-        lastModified: 'December 10th, 2023',
-    },
-    {
-        versionId: 'a8bc2d4d-0a11-4733-919c-4bf03e5b0262',
-        version: 2,
-        deploymentStatus: 'Active',
-        createdBy: 'Steve O',
-        lastModified: 'December 9th, 2023',
-    },
-    {
-        versionId: 'b2425027-64d7-45a0-a91b-e6e4805841dd',
-        version: 1,
-        deploymentStatus: 'Archived',
-        createdBy: 'Steve O',
-        lastModified: 'December 8th, 2023',
-    },
-];
+import { useListModelVersions } from './api';
 
 export const ModelVersion = () => {
     const { pathname } = useLocation();
@@ -64,7 +26,12 @@ export const ModelVersion = () => {
 
     const modelId = pathname.split('/')[pathname.split('/').length - 1];
 
-    const { data, loading, error } = useGetModel(modelId);
+    const { data: modelData, loading: modelLoading, error: modelError } = useGetModel(modelId);
+    const {
+        data: mlVersionData,
+        loading: mlVersionLoading,
+        error: mlVersionError,
+    } = useListModelVersions(modelId);
 
     const [isTooltipHidden, setIsTooltipHidden] = useState(true);
     const [copiedVersionId, setCopiedVersionId] = useState('');
@@ -83,12 +50,14 @@ export const ModelVersion = () => {
         }
     };
 
-    const modelName = data && data.getMLModel && data.getMLModel.modelName;
+    const modelName = modelData && modelData.getMLModel && modelData.getMLModel.modelName;
 
-    if (loading) return <BarLoader color='#4f46e5' width='250' />;
+    if (modelLoading || mlVersionLoading) return <BarLoader color='#4f46e5' width='250' />;
 
     // TODO: Better UX
-    if (error) return <p>Error! {error.message}</p>;
+    if (modelError) return <p>Error! {modelError.message}</p>;
+
+    if (mlVersionError) return <p>Error! {mlVersionError.message}</p>;
 
     return (
         <div className='w-full flex flex-col gap-12'>
@@ -120,42 +89,37 @@ export const ModelVersion = () => {
                     <TableRow>
                         <TableHeaderCell>Version ID</TableHeaderCell>
                         <TableHeaderCell>Version</TableHeaderCell>
-                        <TableHeaderCell>Deployment Status</TableHeaderCell>
                         <TableHeaderCell>Created By</TableHeaderCell>
                         <TableHeaderCell>Last Modified</TableHeaderCell>
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {models.map((model) => (
-                        <TableRow key={model.versionId}>
-                            <TableCell
-                                className='hover:text-gray-800 hover:cursor-pointer'
-                                onClick={() => handleCopy(model.versionId)}
-                            >
-                                <Tooltip
-                                    isVisible={
-                                        !isTooltipHidden && model.versionId === copiedVersionId
-                                    }
-                                    message='Copied!'
+                    {mlVersionData &&
+                        mlVersionData.listMLModelVersions &&
+                        mlVersionData.listMLModelVersions.map((mlVersion) => (
+                            <TableRow key={mlVersion.modelVersionId}>
+                                <TableCell
+                                    className='hover:text-gray-800 hover:cursor-pointer'
+                                    onClick={() => handleCopy(mlVersion.modelVersionId)}
                                 >
-                                    <div className='flex items-center gap-1'>
-                                        <div>{model.versionId.substring(0, 8)}...</div>
-                                        <ClipboardIcon className='h-3 w-3 shrink-0 hover:text-gray-800 hover:cursor-pointer' />
-                                    </div>
-                                </Tooltip>
-                            </TableCell>
-                            <TableCell>{model.version}</TableCell>
-                            <TableCell>
-                                <Badge
-                                    variant={model.deploymentStatus as keyof BadgeProps['variant']}
-                                >
-                                    {model.deploymentStatus}
-                                </Badge>
-                            </TableCell>
-                            <TableCell>{model.createdBy}</TableCell>
-                            <TableCell>{model.lastModified}</TableCell>
-                        </TableRow>
-                    ))}
+                                    <Tooltip
+                                        isVisible={
+                                            !isTooltipHidden &&
+                                            mlVersion.modelVersionId === copiedVersionId
+                                        }
+                                        message='Copied!'
+                                    >
+                                        <div className='flex items-center gap-1'>
+                                            <div>{mlVersion.modelVersionId.substring(0, 8)}...</div>
+                                            <ClipboardIcon className='h-3 w-3 shrink-0 hover:text-gray-800 hover:cursor-pointer' />
+                                        </div>
+                                    </Tooltip>
+                                </TableCell>
+                                <TableCell>{mlVersion.numericVersion}</TableCell>
+                                <TableCell>{mlVersion.createdBy}</TableCell>
+                                <TableCell>{mlVersion.dateCreated}</TableCell>
+                            </TableRow>
+                        ))}
                 </TableBody>
             </Table>
         </div>

--- a/src/routes/model-version/index.tsx
+++ b/src/routes/model-version/index.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { ClipboardIcon } from '@heroicons/react/24/outline';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { BarLoader } from 'react-spinners';
+
+import { useGetModel } from '@/hooks';
 
 import {
     Badge,
@@ -61,6 +64,8 @@ export const ModelVersion = () => {
 
     const modelId = pathname.split('/')[pathname.split('/').length - 1];
 
+    const { data, loading, error } = useGetModel(modelId);
+
     const [isTooltipHidden, setIsTooltipHidden] = useState(true);
     const [copiedVersionId, setCopiedVersionId] = useState('');
 
@@ -78,6 +83,13 @@ export const ModelVersion = () => {
         }
     };
 
+    const modelName = data && data.getMLModel && data.getMLModel.modelName;
+
+    if (loading) return <BarLoader color='#4f46e5' width='250' />;
+
+    // TODO: Better UX
+    if (error) return <p>Error! {error.message}</p>;
+
     return (
         <div className='w-full flex flex-col gap-12'>
             {/* Page Header */}
@@ -87,13 +99,13 @@ export const ModelVersion = () => {
                         <BreadcrumbItem href='/dashboard/home'>Dashboard</BreadcrumbItem>
                         <BreadcrumbItem href='/dashboard/models'>Models</BreadcrumbItem>
                         <BreadcrumbItem href={`/dashboard/models/${modelId}`}>
-                            Housing Market Clustering
+                            {modelName}
                         </BreadcrumbItem>
                     </Breadcrumbs>
                 </div>
                 <div className='flex items-center justify-between gap-0'>
                     <h2 className='text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight'>
-                        Housing Market Clustering
+                        {modelName}
                     </h2>
                     <Button
                         onClick={() => navigate(`/dashboard/models/${modelId}/create`)}

--- a/src/types/MLModelVersion.ts
+++ b/src/types/MLModelVersion.ts
@@ -13,6 +13,10 @@ export type MLModelVersion = {
     s3Prefix: string;
 };
 
+export type MLModelVersionList = {
+    listMLModelVersions: MLModelVersion[];
+};
+
 export type CreateMLModelVersion = {
     createModelVersion: MLModelVersion;
 };


### PR DESCRIPTION
Ref #2 

This adds in the query that lists the model versions for a specific model. This page is accessible by clicking on one of the models on the model registry page.

Also added in the `getModelById` query to appropriately show the model name in the header section of the page, and so that when the user goes to create a new model version, the breadcrumb items reflect the appropriate `hrefs`.