### PR TITLE
Add Model Registry Pagination

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -118,7 +118,7 @@ export const DashboardLayout = () => {
                 </div>
 
                 {/* Main Content */}
-                <main className='flex-grow overflow-hidden bg-gray-50 px-4 py-6 sm:px-8'>
+                <main className='flex-grow overflow-hidden bg-gray-100 px-4 py-6 sm:px-8'>
                     <Outlet />
                 </main>
             </div>

--- a/src/components/ui/card/Card.tsx
+++ b/src/components/ui/card/Card.tsx
@@ -1,0 +1,19 @@
+import { cn } from '@/lib/cn';
+
+export type CardProps = {
+    children: React.ReactNode;
+} & React.AllHTMLAttributes<HTMLDivElement>;
+
+export const Card = ({ children, className, ...props }: CardProps) => {
+    return (
+        <div
+            className={cn(
+                'divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow',
+                className,
+            )}
+            {...props}
+        >
+            {children}
+        </div>
+    );
+};

--- a/src/components/ui/card/CardBody.tsx
+++ b/src/components/ui/card/CardBody.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/cn';
+
+export type CardBodyProps = {
+    children: React.ReactNode;
+} & React.AllHTMLAttributes<HTMLDivElement>;
+
+export const CardBody = ({ children, className, ...props }: CardBodyProps) => {
+    return (
+        <div className={cn('px-4 py-2 sm:p-4', className)} {...props}>
+            {children}
+        </div>
+    );
+};

--- a/src/components/ui/card/CardFooter.tsx
+++ b/src/components/ui/card/CardFooter.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/cn';
+
+export type CardFooterProps = {
+    children: React.ReactNode;
+} & React.AllHTMLAttributes<HTMLDivElement>;
+
+export const CardFooter = ({ children, className, ...props }: CardFooterProps) => {
+    return (
+        <div className={cn('px-4 py-2 sm:px-6', className)} {...props}>
+            {children}
+        </div>
+    );
+};

--- a/src/components/ui/card/CardHeader.tsx
+++ b/src/components/ui/card/CardHeader.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/cn';
+
+export type CardHeaderProps = {
+    children: React.ReactNode;
+} & React.AllHTMLAttributes<HTMLDivElement>;
+
+export const CardHeader = ({ children, className, ...props }: CardHeaderProps) => {
+    return (
+        <div className={cn('px-4 py-2 sm:px-6', className)} {...props}>
+            {children}
+        </div>
+    );
+};

--- a/src/components/ui/card/index.ts
+++ b/src/components/ui/card/index.ts
@@ -1,0 +1,4 @@
+export * from './Card';
+export * from './CardBody';
+export * from './CardFooter';
+export * from './CardHeader';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,6 +1,7 @@
 export * from './badge';
 export * from './breadcrumb';
 export * from './button';
+export * from './card';
 export * from './divider';
 export * from './dropdown';
 export * from './input';

--- a/src/components/ui/table/Table.tsx
+++ b/src/components/ui/table/Table.tsx
@@ -6,14 +6,8 @@ export type TableProps = {
 
 export const Table = ({ children, className, ...props }: TableProps) => {
     return (
-        <div
-            className={cn(
-                'overflow-hidden whitespace-nowrap overflow-auto shadow ring-1 ring-black ring-opacity-5 sm:rounded-lg',
-                className,
-            )}
-            {...props}
-        >
-            <table className='w-full divide-y divide-gray-300'>{children}</table>
-        </div>
+        <table className={cn('min-w-full divide-y divide-gray-200', className)} {...props}>
+            {children}
+        </table>
     );
 };

--- a/src/components/ui/table/TableCell.tsx
+++ b/src/components/ui/table/TableCell.tsx
@@ -6,13 +6,7 @@ export type TableCellProps = {
 
 export const TableCell = ({ children, className, ...props }: TableCellProps) => {
     return (
-        <td
-            className={cn(
-                'whitespace-nowrap text-gray-500 px-3 py-4 first:pl-4 first:pr-3 first:sm:pl-6',
-                className,
-            )}
-            {...props}
-        >
+        <td className={cn('whitespace-nowrap text-gray-500 px-6 py-4', className)} {...props}>
             {children}
         </td>
     );

--- a/src/components/ui/table/TableHead.tsx
+++ b/src/components/ui/table/TableHead.tsx
@@ -6,7 +6,7 @@ export type TableHeadProps = {
 
 export const TableHead = ({ children, className, ...props }: TableHeadProps) => {
     return (
-        <thead className={cn('bg-gray-100', className)} {...props}>
+        <thead className={cn('bg-gray-50', className)} {...props}>
             {children}
         </thead>
     );

--- a/src/components/ui/table/TableHeaderCell.tsx
+++ b/src/components/ui/table/TableHeaderCell.tsx
@@ -6,13 +6,7 @@ export type TableHeaderCellProps = {
 
 export const TableHeaderCell = ({ children, className, ...props }: TableHeaderCellProps) => {
     return (
-        <th
-            className={cn(
-                'text-gray-900 px-3 py-3.5 first:pl-4 first:pr-3 first:sm:pl-6',
-                className,
-            )}
-            {...props}
-        >
+        <th className={cn('px-6 py-3 font-semibold text-gray-900', className)} {...props}>
             {children}
         </th>
     );

--- a/src/components/ui/table/TableRow.tsx
+++ b/src/components/ui/table/TableRow.tsx
@@ -6,7 +6,7 @@ export type TableRowProps = {
 
 export const TableRow = ({ children, className, ...props }: TableRowProps) => {
     return (
-        <tr className={cn('text-sm text-left group', className)} {...props}>
+        <tr className={cn('text-sm text-left', className)} {...props}>
             {children}
         </tr>
     );

--- a/src/constants/limits.ts
+++ b/src/constants/limits.ts
@@ -1,0 +1,1 @@
+export const LIMITS = [10, 25, 50] as const;

--- a/src/routes/model-registry/api/listModels.ts
+++ b/src/routes/model-registry/api/listModels.ts
@@ -3,8 +3,8 @@ import { gql, useQuery, type TypedDocumentNode } from '@apollo/client';
 import type { MLModelList } from '@/types/MLModel';
 
 const LIST_MODELS: TypedDocumentNode<MLModelList> = gql`
-    query ListMLModels($modelName: String) {
-        listMLModels(modelName: $modelName) {
+    query ListMLModels($limit: Limit, $offset: Int, $modelName: String) {
+        listMLModels(limit: $limit, offset: $offset, modelName: $modelName) {
             modelName
             modelId
             createdBy
@@ -17,4 +17,11 @@ const LIST_MODELS: TypedDocumentNode<MLModelList> = gql`
     }
 `;
 
-export const useListModels = () => useQuery(LIST_MODELS);
+export const useListModels = (limit?: 10 | 25 | 50, offset?: number, modelName?: string) =>
+    useQuery(LIST_MODELS, {
+        variables: {
+            modelName: modelName,
+            limit: limit,
+            offset: offset,
+        },
+    });

--- a/src/routes/model-registry/index.tsx
+++ b/src/routes/model-registry/index.tsx
@@ -25,6 +25,9 @@ import { useListModels } from './api';
 import { ArchiveModal } from './components';
 
 export const ModelRegistry = () => {
+    const [limit, setLimit] = useState<10 | 25 | 50>(10);
+    const [offset, setOffset] = useState(0);
+
     const [selectedModel, setSelectedModel] = useState({
         modelId: '',
         modelName: '',
@@ -33,7 +36,7 @@ export const ModelRegistry = () => {
 
     const navigate = useNavigate();
 
-    const { data, loading, error, refetch } = useListModels();
+    const { data, loading, error, refetch } = useListModels(limit, offset);
 
     // TODO: Make UX Prettier
     if (error) return <p>Error: {error.message}</p>;

--- a/src/routes/model-registry/index.tsx
+++ b/src/routes/model-registry/index.tsx
@@ -3,6 +3,8 @@ import { EllipsisHorizontalIcon } from '@heroicons/react/24/outline';
 import { useNavigate } from 'react-router-dom';
 import { BarLoader } from 'react-spinners';
 
+import type { Limit } from '@/types/limit';
+
 import {
     BreadcrumbItem,
     Breadcrumbs,
@@ -14,6 +16,8 @@ import {
     DropdownItem,
     DropdownItems,
     Input,
+    Select,
+    SelectItem,
     Table,
     TableBody,
     TableCell,
@@ -27,7 +31,7 @@ import { useListModels } from './api';
 import { ArchiveModal } from './components';
 
 export const ModelRegistry = () => {
-    const [limit, setLimit] = useState<10 | 25 | 50>(10);
+    const [limit, setLimit] = useState<Limit>(10);
     const [offset, setOffset] = useState(0);
 
     const [selectedModel, setSelectedModel] = useState({
@@ -76,6 +80,14 @@ export const ModelRegistry = () => {
                                 placeholder='Search Models'
                             />
                         </div>
+                        <Select
+                            className='basis-1/6'
+                            onChange={(e) => setLimit(parseInt(e.target.value) as Limit)}
+                        >
+                            <SelectItem value='10'>10 Results</SelectItem>
+                            <SelectItem value='25'>25 Results</SelectItem>
+                            <SelectItem value='50'>50 Results</SelectItem>
+                        </Select>
                     </div>
                     {!loading ? (
                         <Card>

--- a/src/routes/model-registry/index.tsx
+++ b/src/routes/model-registry/index.tsx
@@ -7,6 +7,8 @@ import {
     BreadcrumbItem,
     Breadcrumbs,
     Button,
+    Card,
+    CardFooter,
     Divider,
     Dropdown,
     DropdownItem,
@@ -76,79 +78,122 @@ export const ModelRegistry = () => {
                         </div>
                     </div>
                     {!loading ? (
-                        <Table>
-                            <TableHead>
-                                <TableRow>
-                                    <TableHeaderCell>Name</TableHeaderCell>
-                                    <TableHeaderCell>Total Versions</TableHeaderCell>
-                                    <TableHeaderCell>Created By</TableHeaderCell>
-                                    <TableHeaderCell>Last Modified</TableHeaderCell>
-                                    <TableHeaderCell>
-                                        <span className='sr-only'>Model Registry Actions</span>
-                                    </TableHeaderCell>
-                                </TableRow>
-                            </TableHead>
-                            <TableBody>
-                                {data &&
-                                    data.listMLModels &&
-                                    data.listMLModels.map((model) => (
-                                        <TableRow
-                                            className='hover:bg-gray-50 hover:cursor-pointer'
-                                            key={model.modelId}
+                        <Card>
+                            <Table>
+                                <TableHead>
+                                    <TableRow>
+                                        <TableHeaderCell>Name</TableHeaderCell>
+                                        <TableHeaderCell className='text-right'>
+                                            Total Versions
+                                        </TableHeaderCell>
+                                        <TableHeaderCell className='text-right'>
+                                            Created By
+                                        </TableHeaderCell>
+                                        <TableHeaderCell className='text-right'>
+                                            Last Modified
+                                        </TableHeaderCell>
+                                        <TableHeaderCell>
+                                            <span className='sr-only'>Model Registry Actions</span>
+                                        </TableHeaderCell>
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    {data &&
+                                        data.listMLModels &&
+                                        data.listMLModels.map((model) => (
+                                            <TableRow
+                                                className='hover:bg-gray-50 hover:cursor-pointer'
+                                                key={model.modelId}
+                                                onClick={() =>
+                                                    navigate(`/dashboard/models/${model.modelId}`)
+                                                }
+                                            >
+                                                <TableCell className='font-medium text-gray-900'>
+                                                    {model.modelName}
+                                                </TableCell>
+                                                <TableCell className='text-right'>
+                                                    {(model.currentModelVersion &&
+                                                        model.currentModelVersion.numericVersion) ||
+                                                        0}
+                                                </TableCell>
+                                                <TableCell className='text-right'>
+                                                    {model.createdBy}
+                                                </TableCell>
+                                                <TableCell className='text-right'>
+                                                    {model.dateModified}
+                                                </TableCell>
+                                                <TableCell className='text-right'>
+                                                    <Dropdown
+                                                        menuButton={
+                                                            <EllipsisHorizontalIcon className='h-6 w-6' />
+                                                        }
+                                                    >
+                                                        <DropdownItems>
+                                                            <DropdownItem>
+                                                                <a
+                                                                    href={`/dashboard/models/${model.modelId}/edit`}
+                                                                >
+                                                                    Edit
+                                                                </a>
+                                                            </DropdownItem>
+                                                            <DropdownItem>
+                                                                <button
+                                                                    onClick={() => {
+                                                                        setSelectedModel({
+                                                                            modelId: model.modelId,
+                                                                            modelName:
+                                                                                model.modelName,
+                                                                        });
+                                                                        setArchiveModalOpen(true);
+                                                                    }}
+                                                                >
+                                                                    Archive
+                                                                </button>
+                                                            </DropdownItem>
+                                                            <Divider />
+                                                            <DropdownItem>
+                                                                <span className='text-indigo-600 font-semibold'>
+                                                                    Publish
+                                                                </span>
+                                                            </DropdownItem>
+                                                        </DropdownItems>
+                                                    </Dropdown>
+                                                </TableCell>
+                                            </TableRow>
+                                        ))}
+                                </TableBody>
+                            </Table>
+                            <CardFooter>
+                                <div className='flex items-center justify-between'>
+                                    {/* Dummy values */}
+                                    <p className='text-sm text-gray-700'>
+                                        Showing <span className='font-medium'>1</span> to{' '}
+                                        <span className='font-medium'>3</span> of{' '}
+                                        <span className='font-medium'>3</span> results
+                                    </p>
+                                    <div className='flex items-center gap-x-3'>
+                                        <Button
+                                            variant='secondary'
+                                            size='lg'
                                             onClick={() =>
-                                                navigate(`/dashboard/models/${model.modelId}`)
+                                                setOffset((offset) =>
+                                                    offset > 0 ? offset - 1 : offset,
+                                                )
                                             }
                                         >
-                                            <TableCell className='font-medium text-gray-900'>
-                                                {model.modelName}
-                                            </TableCell>
-                                            <TableCell>
-                                                {(model.currentModelVersion &&
-                                                    model.currentModelVersion.numericVersion) ||
-                                                    0}
-                                            </TableCell>
-                                            <TableCell>{model.createdBy}</TableCell>
-                                            <TableCell>{model.dateModified}</TableCell>
-                                            <TableCell>
-                                                <Dropdown
-                                                    menuButton={
-                                                        <EllipsisHorizontalIcon className='h-6 w-6' />
-                                                    }
-                                                >
-                                                    <DropdownItems>
-                                                        <DropdownItem>
-                                                            <a
-                                                                href={`/dashboard/models/${model.modelId}/edit`}
-                                                            >
-                                                                Edit
-                                                            </a>
-                                                        </DropdownItem>
-                                                        <DropdownItem>
-                                                            <button
-                                                                onClick={() => {
-                                                                    setSelectedModel({
-                                                                        modelId: model.modelId,
-                                                                        modelName: model.modelName,
-                                                                    });
-                                                                    setArchiveModalOpen(true);
-                                                                }}
-                                                            >
-                                                                Archive
-                                                            </button>
-                                                        </DropdownItem>
-                                                        <Divider />
-                                                        <DropdownItem>
-                                                            <span className='text-indigo-600 font-semibold'>
-                                                                Publish
-                                                            </span>
-                                                        </DropdownItem>
-                                                    </DropdownItems>
-                                                </Dropdown>
-                                            </TableCell>
-                                        </TableRow>
-                                    ))}
-                            </TableBody>
-                        </Table>
+                                            Previous
+                                        </Button>
+                                        <Button
+                                            variant='secondary'
+                                            size='lg'
+                                            onClick={() => setOffset((offset) => offset + 1)}
+                                        >
+                                            Next
+                                        </Button>
+                                    </div>
+                                </div>
+                            </CardFooter>
+                        </Card>
                     ) : (
                         <BarLoader color='#4f46e5' width='250' />
                     )}

--- a/src/routes/model-version/index.tsx
+++ b/src/routes/model-version/index.tsx
@@ -9,6 +9,7 @@ import {
     BreadcrumbItem,
     Breadcrumbs,
     Button,
+    Card,
     Table,
     TableBody,
     TableCell,
@@ -84,44 +85,48 @@ export const ModelVersion = () => {
                     </Button>
                 </div>
             </header>
-            <Table>
-                <TableHead>
-                    <TableRow>
-                        <TableHeaderCell>Version ID</TableHeaderCell>
-                        <TableHeaderCell>Version</TableHeaderCell>
-                        <TableHeaderCell>Created By</TableHeaderCell>
-                        <TableHeaderCell>Last Modified</TableHeaderCell>
-                    </TableRow>
-                </TableHead>
-                <TableBody>
-                    {mlVersionData &&
-                        mlVersionData.listMLModelVersions &&
-                        mlVersionData.listMLModelVersions.map((mlVersion) => (
-                            <TableRow key={mlVersion.modelVersionId}>
-                                <TableCell
-                                    className='hover:text-gray-800 hover:cursor-pointer'
-                                    onClick={() => handleCopy(mlVersion.modelVersionId)}
-                                >
-                                    <Tooltip
-                                        isVisible={
-                                            !isTooltipHidden &&
-                                            mlVersion.modelVersionId === copiedVersionId
-                                        }
-                                        message='Copied!'
+            <Card>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableHeaderCell>Version ID</TableHeaderCell>
+                            <TableHeaderCell>Version</TableHeaderCell>
+                            <TableHeaderCell>Created By</TableHeaderCell>
+                            <TableHeaderCell>Last Modified</TableHeaderCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {mlVersionData &&
+                            mlVersionData.listMLModelVersions &&
+                            mlVersionData.listMLModelVersions.map((mlVersion) => (
+                                <TableRow key={mlVersion.modelVersionId}>
+                                    <TableCell
+                                        className='hover:text-gray-800 hover:cursor-pointer'
+                                        onClick={() => handleCopy(mlVersion.modelVersionId)}
                                     >
-                                        <div className='flex items-center gap-1'>
-                                            <div>{mlVersion.modelVersionId.substring(0, 8)}...</div>
-                                            <ClipboardIcon className='h-3 w-3 shrink-0 hover:text-gray-800 hover:cursor-pointer' />
-                                        </div>
-                                    </Tooltip>
-                                </TableCell>
-                                <TableCell>{mlVersion.numericVersion}</TableCell>
-                                <TableCell>{mlVersion.createdBy}</TableCell>
-                                <TableCell>{mlVersion.dateCreated}</TableCell>
-                            </TableRow>
-                        ))}
-                </TableBody>
-            </Table>
+                                        <Tooltip
+                                            isVisible={
+                                                !isTooltipHidden &&
+                                                mlVersion.modelVersionId === copiedVersionId
+                                            }
+                                            message='Copied!'
+                                        >
+                                            <div className='flex items-center gap-1'>
+                                                <div>
+                                                    {mlVersion.modelVersionId.substring(0, 8)}...
+                                                </div>
+                                                <ClipboardIcon className='h-3 w-3 shrink-0 hover:text-gray-800 hover:cursor-pointer' />
+                                            </div>
+                                        </Tooltip>
+                                    </TableCell>
+                                    <TableCell>{mlVersion.numericVersion}</TableCell>
+                                    <TableCell>{mlVersion.createdBy}</TableCell>
+                                    <TableCell>{mlVersion.dateCreated}</TableCell>
+                                </TableRow>
+                            ))}
+                    </TableBody>
+                </Table>
+            </Card>
         </div>
     );
 };

--- a/src/types/limit.ts
+++ b/src/types/limit.ts
@@ -1,0 +1,3 @@
+import { LIMITS } from '@/constants/limits';
+
+export type Limit = (typeof LIMITS)[number];


### PR DESCRIPTION
Ref #3 

Decent amount of file changes, but it's mostly nit-picky styling stuff.

This adds in the "next" and "previous" buttons that allows users to paginate. Also adds in a select menu where users can choose to show 10, 25, or 50 results per page. Finally, I added in a "you're looking at page X of Y results". These are hard coded, as I'll add in that query in a future PR.

I wanted to include the pagination UI inside of the table card. To get that looking good, I removed the old wrapper that was on the `<Table />` component and created some `<Card>` components for a more intuitive component composition.

I also ended up changing the style of the dashboard background to represent better visual hierarchy w/ the shadows of the cards. As a result, I also tweaked some of the table styles.

As a side note, I think we're at the point where these page components are pretty big, so I'll be circling back in a future PR to bring the size of the code down.

Here is what the UI looks like:

<img width="1024" alt="image" src="https://github.com/dstk-labs/dstk-web/assets/77359138/57536f1d-b056-4d0f-869c-83072efa2cbb">
