### PR TITLE
Fix Queries and Mutations based on Recent Schema Changes

### DIFF
--- a/src/providers/ApolloProvider.tsx
+++ b/src/providers/ApolloProvider.tsx
@@ -7,14 +7,15 @@ import {
 import { setContext } from '@apollo/client/link/context';
 
 const httpLink = createHttpLink({
-    uri: 'http://localhost:4000/',
+    uri: 'http://localhost:4000',
 });
 
-const authLink = setContext(() => {
+const authLink = setContext((_, { headers }) => {
+    const token = localStorage.getItem('token');
     return {
         headers: {
-            ...Headers,
-            authorization: `Bearer ${localStorage.getItem('token') || ''}`,
+            ...headers,
+            authorization: token ? `Bearer ${JSON.parse(token)}` : '',
         },
     };
 });

--- a/src/routes/create-model-version/api/createModelVersion.ts
+++ b/src/routes/create-model-version/api/createModelVersion.ts
@@ -3,7 +3,7 @@ import { gql, useMutation, type TypedDocumentNode } from '@apollo/client';
 import { CreateMLModelVersion } from '@/types/MLModelVersion';
 
 const CREATE_MODEL_VERSION: TypedDocumentNode<CreateMLModelVersion> = gql`
-    mutation CreateModelVersion($data: ModelVersionInputType!) {
+    mutation CreateModelVersion($data: ModelVersionInput!) {
         createModelVersion(data: $data) {
             modelVersionId
             modelId {

--- a/src/routes/model-registry/api/listModels.ts
+++ b/src/routes/model-registry/api/listModels.ts
@@ -1,27 +1,45 @@
-import { gql, useQuery, type TypedDocumentNode } from '@apollo/client';
+import { gql, useQuery, type TypedDocumentNode, type QueryDataOptions } from '@apollo/client';
 
 import type { MLModelList } from '@/types/MLModel';
+import type { Limit } from '@/types/Limit';
 
 const LIST_MODELS: TypedDocumentNode<MLModelList> = gql`
-    query ListMLModels($limit: Limit, $offset: Int, $modelName: String) {
-        listMLModels(limit: $limit, offset: $offset, modelName: $modelName) {
-            modelName
-            modelId
-            createdBy
-            dateCreated
-            currentModelVersion {
-                modelVersionId
-                numericVersion
+    query ListMLModels($after: String, $first: Limit, $modelName: String) {
+        listMLModels(after: $after, first: $first, modelName: $modelName) {
+            edges {
+                cursor
+                node {
+                    modelId
+                    modelName
+                    currentModelVersion {
+                        numericVersion
+                    }
+                    createdBy {
+                        userName
+                    }
+                }
+            }
+            pageInfo {
+                hasPreviousPage
+                hasNextPage
+                continuationToken
             }
         }
     }
 `;
 
-export const useListModels = (limit?: 10 | 25 | 50, offset?: number, modelName?: string) =>
+type ListModelOptions = {
+    after?: string;
+    first?: Limit;
+    modelName?: string;
+} & Omit<QueryDataOptions, 'query'>;
+
+export const useListModels = ({ after, first = 10, modelName, ...args }: ListModelOptions) =>
     useQuery(LIST_MODELS, {
         variables: {
+            after: after,
+            first: first,
             modelName: modelName,
-            limit: limit,
-            offset: offset,
         },
+        ...args,
     });

--- a/src/routes/model-version/api/listModelVersions.ts
+++ b/src/routes/model-version/api/listModelVersions.ts
@@ -5,7 +5,9 @@ import type { MLModelVersionList } from '@/types/MLModelVersion';
 const LIST_MODEL_VERSIONS: TypedDocumentNode<MLModelVersionList> = gql`
     query ListMLModelVersions($modelId: String!) {
         listMLModelVersions(modelId: $modelId) {
-            createdBy
+            createdBy {
+                userName
+            }
             dateCreated
             modelVersionId
             numericVersion

--- a/src/routes/model-version/index.tsx
+++ b/src/routes/model-version/index.tsx
@@ -120,7 +120,7 @@ export const ModelVersion = () => {
                                         </Tooltip>
                                     </TableCell>
                                     <TableCell>{mlVersion.numericVersion}</TableCell>
-                                    <TableCell>{mlVersion.createdBy}</TableCell>
+                                    <TableCell>{mlVersion.createdBy.userName}</TableCell>
                                     <TableCell>{mlVersion.dateCreated}</TableCell>
                                 </TableRow>
                             ))}

--- a/src/types/Cursor.ts
+++ b/src/types/Cursor.ts
@@ -1,0 +1,10 @@
+export type Edge<T> = {
+    cursor: string;
+    node: T;
+};
+
+export type PageInfo = {
+    hasPreviousPage: boolean;
+    hasNextPage: boolean;
+    continuationToken: string;
+};

--- a/src/types/MLModel.ts
+++ b/src/types/MLModel.ts
@@ -1,5 +1,7 @@
-import { MLModelVersion } from './MLModelVersion';
-import { StorageProvider } from './StorageProvider';
+import { Edge, PageInfo } from './Cursor';
+import type { MLModelVersion } from './MLModelVersion';
+import type { StorageProvider } from './StorageProvider';
+import type { User } from './User';
 
 export type MLModel = {
     modelId: string;
@@ -7,8 +9,8 @@ export type MLModel = {
     currentModelVersion?: MLModelVersion;
     isArchived: boolean;
     modelName: string;
-    createdBy: string; // TODO: User Object
-    modifiedBy: string; // TODO: User Object
+    createdBy: User;
+    modifiedBy: User;
     dateCreated: string;
     dateModified: string;
     description: string;
@@ -20,7 +22,10 @@ export type GetMLModel = {
 };
 
 export type MLModelList = {
-    listMLModels: MLModel[];
+    listMLModels: {
+        edges: Edge<MLModel>[];
+        pageInfo: PageInfo;
+    };
 };
 
 export type CreateMLModel = {

--- a/src/types/MLModelVersion.ts
+++ b/src/types/MLModelVersion.ts
@@ -1,11 +1,12 @@
 import { MLModel } from './MLModel';
+import { User } from './User';
 
 export type MLModelVersion = {
     modelVersionId: string;
     modelId: MLModel;
     isArchived: boolean;
     isFinalized: boolean;
-    createdBy: string; // TODO: User Object
+    createdBy: User;
     numericVersion: number;
     description: string;
     // TODO: metadata

--- a/src/types/StorageProvider.ts
+++ b/src/types/StorageProvider.ts
@@ -1,3 +1,5 @@
+import { User } from './User';
+
 export type StorageProvider = {
     providerId: string;
     endpointUrl: string;
@@ -5,9 +7,9 @@ export type StorageProvider = {
     bucket: string;
     accessKeyId: string;
     secretAccessKey: string;
-    createdBy: string; // TODO: User Object
-    modifiedBy: string; // TODO: User Object
-    owner: string; // TODO: User Object
+    createdBy: User;
+    modifiedBy: User;
+    owner: User;
     dateCreated: string;
     dateModified: string;
     isArchvied: boolean;

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,11 @@
+export type User = {
+    dateCreated: string;
+    dateModified: string;
+    isAdmin: boolean;
+    isApproved: boolean;
+    isDisabled: boolean;
+    primaryEmail: string;
+    realName: string;
+    userId: string;
+    userName: string;
+};


### PR DESCRIPTION
There have been several additions to the API. This PR integrates these changes on the backend such that all existing queries and mutations resolve without error. More specifically:

- Added new types related to the pagination spec
- Added new types for Users
- Integrated the types above with the existing queries and mutations
- Altered the local state for the model registry page to appropriately resolve the `listMLModels` query.

A fix was also put in for storing the JWT tokens in local storage. Apparently, local storage will add quotations to values being returned from storage. Therefore, when adding the authorization header to the graphQL server, it was receiving `Bearer "token"` instead of `Bearer token`.