### PR TITLE
Refactor Model Registry Page

### DIFF
--- a/src/routes/model-registry/atoms/archiveModalOpenAtom.ts
+++ b/src/routes/model-registry/atoms/archiveModalOpenAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const archiveModalOpenAtom = atom(false);

--- a/src/routes/model-registry/atoms/index.ts
+++ b/src/routes/model-registry/atoms/index.ts
@@ -1,0 +1,3 @@
+export * from './archiveModalOpenAtom';
+export * from './modelRegistryPaginationAtom';
+export * from './selectedModelAtom';

--- a/src/routes/model-registry/atoms/modelRegistryPaginationAtom.ts
+++ b/src/routes/model-registry/atoms/modelRegistryPaginationAtom.ts
@@ -1,0 +1,18 @@
+import { atom } from 'jotai';
+import type { Limit } from '@/types/Limit';
+
+type ModelRegistryPaginationInput = {
+    first: Limit;
+    continuationTokens: (string | undefined)[];
+    hasPreviousPage: boolean;
+    hasNextPage: boolean;
+    modelName?: string;
+};
+
+export const modelRegistryPaginationAtom = atom<ModelRegistryPaginationInput>({
+    first: 10,
+    continuationTokens: [undefined],
+    hasPreviousPage: false,
+    hasNextPage: false,
+    modelName: undefined,
+});

--- a/src/routes/model-registry/atoms/selectedModelAtom.ts
+++ b/src/routes/model-registry/atoms/selectedModelAtom.ts
@@ -1,0 +1,6 @@
+import { atom } from 'jotai';
+
+export const selectedModelAtom = atom({
+    modelId: '',
+    modelName: '',
+});

--- a/src/routes/model-registry/components/ArchiveModal.tsx
+++ b/src/routes/model-registry/components/ArchiveModal.tsx
@@ -1,8 +1,6 @@
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
-import { BarLoader } from 'react-spinners';
 
 import { useNotificationStore } from '@/stores';
-
 import {
     Button,
     Modal,
@@ -29,53 +27,45 @@ export const ArchiveModal = ({ isOpen, onClose, model }: ArchiveModalProps) => {
 
     const [archiveModel, { loading }] = useArchiveModel();
 
+    const handleArchive = () => {
+        archiveModel({
+            variables: {
+                modelId: model.modelId,
+            },
+            onCompleted: onClose,
+            onError: (error) =>
+                addNotification({
+                    type: 'error',
+                    title: 'Error',
+                    children: error.message,
+                }),
+        });
+    };
+
     return (
         <Modal isOpen={isOpen} onClose={onClose}>
-            {!loading ? (
-                <>
-                    <ModalContents>
-                        <ModalIcon>
-                            <ExclamationTriangleIcon className='h-6 w-6 text-red-600' />
-                        </ModalIcon>
-                        <ModalBody>
-                            <ModalTitle>Archive {model.modelName}</ModalTitle>
-                            <div className='pt-2'>
-                                <p className='text-sm text-gray-500'>
-                                    Are you sure you want to perform this action? Edits cannot be
-                                    performed while a model is in an archived state.
-                                </p>
-                            </div>
-                        </ModalBody>
-                    </ModalContents>
-                    <ModalFooter>
-                        <Button
-                            size='lg'
-                            variant='destructive'
-                            onClick={() => {
-                                archiveModel({
-                                    variables: {
-                                        modelId: model.modelId,
-                                    },
-                                    onCompleted: onClose,
-                                    onError: (error) =>
-                                        addNotification({
-                                            type: 'error',
-                                            title: 'Error',
-                                            children: error.message,
-                                        }),
-                                });
-                            }}
-                        >
-                            Archive
-                        </Button>
-                        <Button size='lg' variant='secondary' onClick={onClose}>
-                            Cancel
-                        </Button>
-                    </ModalFooter>
-                </>
-            ) : (
-                <BarLoader color='#4f46e5' width='250' />
-            )}
+            <ModalContents>
+                <ModalIcon>
+                    <ExclamationTriangleIcon className='h-6 w-6 text-red-600' />
+                </ModalIcon>
+                <ModalBody>
+                    <ModalTitle>Archive {model.modelName}</ModalTitle>
+                    <div className='pt-2'>
+                        <p className='text-sm text-gray-500'>
+                            Are you sure you want to perform this action? Edits cannot be performed
+                            while a model is in an archived state.
+                        </p>
+                    </div>
+                </ModalBody>
+            </ModalContents>
+            <ModalFooter>
+                <Button onClick={() => handleArchive()} loading={loading} variant='destructive'>
+                    Archive
+                </Button>
+                <Button variant='secondary' onClick={onClose}>
+                    Cancel
+                </Button>
+            </ModalFooter>
         </Modal>
     );
 };

--- a/src/routes/model-registry/components/ModelRegistryFilters.tsx
+++ b/src/routes/model-registry/components/ModelRegistryFilters.tsx
@@ -1,0 +1,40 @@
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { useSetAtom } from 'jotai';
+
+import type { Limit } from '@/types/Limit';
+import { Input, Select, SelectItem } from '@/components/ui';
+
+import { modelRegistryPaginationAtom } from '../atoms';
+
+export const ModelRegistryFilters = () => {
+    const setInputs = useSetAtom(modelRegistryPaginationAtom);
+
+    const handleInput = (e: React.ChangeEvent<HTMLInputElement>) =>
+        setInputs((values) => ({
+            ...values,
+            modelName: e.target.value,
+        }));
+
+    const handleSelect = (e: React.ChangeEvent<HTMLSelectElement>) =>
+        setInputs((values) => ({
+            ...values,
+            limit: parseInt(e.target.value) as Limit,
+        }));
+
+    return (
+        <div className='flex items-center justify-between'>
+            <div className='basis-1/4'>
+                <Input
+                    icon={MagnifyingGlassIcon}
+                    onChange={(e) => handleInput(e)}
+                    placeholder='Search Models'
+                />
+            </div>
+            <Select className='basis-1/6' onChange={(e) => handleSelect(e)}>
+                <SelectItem value='10'>10 Results</SelectItem>
+                <SelectItem value='25'>25 Results</SelectItem>
+                <SelectItem value='50'>50 Results</SelectItem>
+            </Select>
+        </div>
+    );
+};

--- a/src/routes/model-registry/components/ModelRegistryHeader.tsx
+++ b/src/routes/model-registry/components/ModelRegistryHeader.tsx
@@ -1,0 +1,30 @@
+import { PlusCircleIcon } from '@heroicons/react/24/outline';
+import { type NavigateFunction } from 'react-router-dom';
+
+import { BreadcrumbItem, Breadcrumbs, Button } from '@/components/ui';
+
+type ModelRegistryHeaderProps = {
+    navigateFn: NavigateFunction;
+};
+
+export const ModelRegistryHeader = ({ navigateFn }: ModelRegistryHeaderProps) => {
+    return (
+        <header className='flex flex-col gap-6'>
+            <div>
+                <Breadcrumbs>
+                    <BreadcrumbItem href='/dashboard/home'>Dashboard</BreadcrumbItem>
+                    <BreadcrumbItem href='/dashboard/models'>Models</BreadcrumbItem>
+                </Breadcrumbs>
+            </div>
+            <div className='flex items-center justify-between gap-0'>
+                <h2 className='text-2xl font-medium text-gray-700 sm:text-3xl'>Model Registry</h2>
+                <Button
+                    onClick={() => navigateFn('/dashboard/models/create')}
+                    icon={PlusCircleIcon}
+                >
+                    Create
+                </Button>
+            </div>
+        </header>
+    );
+};

--- a/src/routes/model-registry/components/ModelRegistryPagination.tsx
+++ b/src/routes/model-registry/components/ModelRegistryPagination.tsx
@@ -1,0 +1,44 @@
+import { useAtom } from 'jotai';
+
+import { Button } from '@/components/ui';
+
+import { modelRegistryPaginationAtom } from '../atoms';
+
+type ModelRegistryPaginationProps = {
+    continuationToken: string;
+};
+
+export const ModelRegistryPagination = ({ continuationToken }: ModelRegistryPaginationProps) => {
+    const [inputs, setInputs] = useAtom(modelRegistryPaginationAtom);
+
+    const handlePrevPage = () =>
+        setInputs((values) => ({
+            ...values,
+            continuationTokens: values.continuationTokens.slice(0, -1),
+        }));
+
+    const handleNextPage = () =>
+        setInputs((values) => ({
+            ...values,
+            continuationTokens: [...values.continuationTokens, continuationToken],
+        }));
+
+    return (
+        <div className='flex items-center justify-end gap-x-3'>
+            <Button
+                variant='secondary'
+                disabled={!inputs.hasPreviousPage}
+                onClick={() => handlePrevPage()}
+            >
+                Previous
+            </Button>
+            <Button
+                variant='secondary'
+                disabled={!inputs.hasNextPage}
+                onClick={() => handleNextPage()}
+            >
+                Next
+            </Button>
+        </div>
+    );
+};

--- a/src/routes/model-registry/components/ModelRegistryTable.tsx
+++ b/src/routes/model-registry/components/ModelRegistryTable.tsx
@@ -1,0 +1,122 @@
+import { EllipsisHorizontalIcon } from '@heroicons/react/24/outline';
+import { useSetAtom } from 'jotai';
+import type { NavigateFunction } from 'react-router-dom';
+
+import {
+    Button,
+    Card,
+    Divider,
+    Dropdown,
+    DropdownItem,
+    DropdownItems,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeaderCell,
+    TableRow,
+} from '@/components/ui';
+import type { MLModelList } from '@/types/MLModel';
+
+import { archiveModalOpenAtom, selectedModelAtom } from '../atoms';
+
+type ModelRegistryTableProps = {
+    data: MLModelList;
+    navigateFn: NavigateFunction;
+};
+
+export const ModelRegistryTable = ({ data, navigateFn }: ModelRegistryTableProps) => {
+    const setArchiveModalOpen = useSetAtom(archiveModalOpenAtom);
+    const setSelectedModel = useSetAtom(selectedModelAtom);
+
+    const handleEdit = (
+        e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+        model: (typeof data.listMLModels.edges)[number],
+    ) => {
+        e.stopPropagation();
+        navigateFn(`/dashboard/models/${model.node.modelId}/edit`);
+    };
+
+    const handleArchive = (
+        e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+        model: (typeof data.listMLModels.edges)[number],
+    ) => {
+        e.stopPropagation();
+        setSelectedModel({
+            modelId: model.node.modelId,
+            modelName: model.node.modelName,
+        });
+        setArchiveModalOpen(true);
+    };
+
+    return (
+        <Card>
+            <Table>
+                <TableHead>
+                    <TableRow>
+                        <TableHeaderCell>Name</TableHeaderCell>
+                        <TableHeaderCell>Total Versions</TableHeaderCell>
+                        <TableHeaderCell>Created By</TableHeaderCell>
+                        <TableHeaderCell>Last Modified</TableHeaderCell>
+                        <TableHeaderCell>
+                            <span className='sr-only'>Model Registry Actions</span>
+                        </TableHeaderCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {data.listMLModels.edges.map((model) => (
+                        <TableRow
+                            className='hover:bg-gray-50 hover:cursor-pointer'
+                            key={model.node.modelId}
+                            onClick={() => navigateFn(`/dashboard/models/${model.node.modelId}`)}
+                        >
+                            <TableCell className='font-medium text-gray-800'>
+                                {model.node.modelName}
+                            </TableCell>
+                            <TableCell>
+                                {(model.node.currentModelVersion &&
+                                    model.node.currentModelVersion.numericVersion) ||
+                                    0}
+                            </TableCell>
+                            <TableCell>
+                                <div className='flex gap-0.5 text-blue-600'>
+                                    <div>@</div>
+                                    <div className='hover:underline'>
+                                        {model.node.createdBy.userName}
+                                    </div>
+                                </div>
+                            </TableCell>
+                            <TableCell>
+                                {new Date(parseInt(model.node.dateModified)).toLocaleDateString()}
+                            </TableCell>
+                            <TableCell>
+                                <Dropdown
+                                    menuButton={
+                                        <Button
+                                            icon={EllipsisHorizontalIcon}
+                                            size='xs'
+                                            variant='ghost'
+                                        />
+                                    }
+                                >
+                                    <DropdownItems>
+                                        <DropdownItem onClick={(e) => handleEdit(e, model)}>
+                                            Edit
+                                        </DropdownItem>
+                                        <DropdownItem onClick={(e) => handleArchive(e, model)}>
+                                            <span>Archive</span>
+                                        </DropdownItem>
+                                        <Divider />
+                                        <DropdownItem className='text-blue-600 font-medium'>
+                                            Publish
+                                        </DropdownItem>
+                                    </DropdownItems>
+                                </Dropdown>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </Card>
+    );
+};

--- a/src/routes/model-registry/components/NoModelsFound.tsx
+++ b/src/routes/model-registry/components/NoModelsFound.tsx
@@ -1,0 +1,17 @@
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+
+export const NoModelsFound = () => {
+    return (
+        <div className='flex items-center mt-6 text-center border rounded-lg h-96'>
+            <div className='flex flex-col w-full max-w-sm px-4 mx-auto'>
+                <div className='p-3 mx-auto text-blue-500 bg-blue-100 rounded-full'>
+                    <MagnifyingGlassIcon className='w-6 h-6' />
+                </div>
+                <h1 className='mt-3 text-lg text-gray-800'>No Models Found</h1>
+                <p className='mt-2 text-gray-500'>
+                    Please update the search criteria or create a new model.
+                </p>
+            </div>
+        </div>
+    );
+};

--- a/src/routes/model-registry/components/index.ts
+++ b/src/routes/model-registry/components/index.ts
@@ -1,1 +1,6 @@
 export * from './ArchiveModal';
+export * from './ModelRegistryFilters';
+export * from './ModelRegistryHeader';
+export * from './ModelRegistryPagination';
+export * from './ModelRegistryTable';
+export * from './NoModelsFound';

--- a/src/routes/model-registry/index.tsx
+++ b/src/routes/model-registry/index.tsx
@@ -1,250 +1,47 @@
-import { useState } from 'react';
-import { EllipsisHorizontalIcon } from '@heroicons/react/24/outline';
+import { useAtom, useAtomValue } from 'jotai';
 import { useNavigate } from 'react-router-dom';
 import { BarLoader } from 'react-spinners';
 
-import type { Limit } from '@/types/Limit';
-
-import {
-    BreadcrumbItem,
-    Breadcrumbs,
-    Button,
-    Card,
-    CardFooter,
-    Divider,
-    Dropdown,
-    DropdownItem,
-    DropdownItems,
-    Input,
-    Select,
-    SelectItem,
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeaderCell,
-    TableRow,
-} from '@/components/ui';
-
+import { archiveModalOpenAtom, selectedModelAtom } from './atoms';
 import { useListModels } from './api';
-
-import { ArchiveModal } from './components';
+import {
+    ArchiveModal,
+    ModelRegistryFilters,
+    ModelRegistryHeader,
+    ModelRegistryPagination,
+    ModelRegistryTable,
+    NoModelsFound,
+} from './components';
 
 export const ModelRegistry = () => {
-    const [limit, setLimit] = useState<Limit>(10);
-    const [continuationTokens, setContinuationTokens] = useState<(string | undefined)[]>([
-        undefined,
-    ]);
-    const [hasPreviousPage, setHasPreviousPage] = useState(false);
-    const [hasNextPage, setHasNextPage] = useState(false);
-
-    const [selectedModel, setSelectedModel] = useState({
-        modelId: '',
-        modelName: '',
-    });
-    const [archiveModalOpen, setArchiveModalOpen] = useState(false);
+    const [archiveModalOpen, setArchiveModalOpen] = useAtom(archiveModalOpenAtom);
+    const selectedModel = useAtomValue(selectedModelAtom);
 
     const navigate = useNavigate();
 
-    const { data, loading, error, refetch, fetchMore } = useListModels({
-        first: limit,
-        onCompleted(data) {
-            setHasPreviousPage(data.listMLModels.pageInfo.hasPreviousPage);
-            setHasNextPage(data.listMLModels.pageInfo.hasNextPage);
-            setContinuationTokens((tokens) => [
-                ...tokens,
-                data.listMLModels.pageInfo.continuationToken,
-            ]);
-        },
-    });
+    const { data, loading, error } = useListModels();
 
-    // TODO: Make UX Prettier
-    if (error) return <p>Error: {error.message}</p>;
+    if (error) return <NoModelsFound />;
 
     return (
         <>
             <div className='w-full flex flex-col gap-12'>
-                {/* Page Header */}
-                <header className='flex flex-col gap-4'>
-                    <div>
-                        <Breadcrumbs>
-                            <BreadcrumbItem href='/dashboard/home'>Dashboard</BreadcrumbItem>
-                            <BreadcrumbItem href='/dashboard/models'>Models</BreadcrumbItem>
-                        </Breadcrumbs>
-                    </div>
-                    <div className='flex items-center justify-between gap-0'>
-                        <h2 className='text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight'>
-                            Model Registry
-                        </h2>
-                        <Button onClick={() => navigate('/dashboard/models/create')} size='lg'>
-                            Create
-                        </Button>
-                    </div>
-                </header>
-                {/* TODO: Add in indicator that lets user know there are no models current registered */}
+                <ModelRegistryHeader navigateFn={navigate} />
                 <div className='flex flex-col gap-4'>
-                    <div className='flex items-center justify-between'>
-                        <div className='basis-1/4'>
-                            <Input
-                                onChange={(e) =>
-                                    refetch({
-                                        variables: {
-                                            modelName: e.target.value,
-                                        },
-                                    })
-                                }
-                                placeholder='Search Models'
+                    <ModelRegistryFilters />
+                    {!loading ? (
+                        <div className='flex flex-col gap-6'>
+                            {data!.listMLModels.edges.length === 0 ? (
+                                <NoModelsFound />
+                            ) : (
+                                <ModelRegistryTable data={data!} navigateFn={navigate} />
+                            )}
+                            <ModelRegistryPagination
+                                continuationToken={data!.listMLModels.pageInfo.continuationToken}
                             />
                         </div>
-                        <Select
-                            className='basis-1/6'
-                            onChange={(e) => setLimit(parseInt(e.target.value) as Limit)}
-                        >
-                            <SelectItem value='10'>10 Results</SelectItem>
-                            <SelectItem value='25'>25 Results</SelectItem>
-                            <SelectItem value='50'>50 Results</SelectItem>
-                        </Select>
-                    </div>
-                    {!loading ? (
-                        <Card>
-                            <Table>
-                                <TableHead>
-                                    <TableRow>
-                                        <TableHeaderCell>Name</TableHeaderCell>
-                                        <TableHeaderCell className='text-right'>
-                                            Total Versions
-                                        </TableHeaderCell>
-                                        <TableHeaderCell className='text-right'>
-                                            Created By
-                                        </TableHeaderCell>
-                                        <TableHeaderCell className='text-right'>
-                                            Last Modified
-                                        </TableHeaderCell>
-                                        <TableHeaderCell>
-                                            <span className='sr-only'>Model Registry Actions</span>
-                                        </TableHeaderCell>
-                                    </TableRow>
-                                </TableHead>
-                                <TableBody>
-                                    {data &&
-                                        data.listMLModels &&
-                                        data.listMLModels.edges.map((model) => (
-                                            <TableRow
-                                                className='hover:bg-gray-50 hover:cursor-pointer'
-                                                key={model.node.modelId}
-                                                onClick={() =>
-                                                    navigate(
-                                                        `/dashboard/models/${model.node.modelId}`,
-                                                    )
-                                                }
-                                            >
-                                                <TableCell className='font-medium text-gray-900'>
-                                                    {model.node.modelName}
-                                                </TableCell>
-                                                <TableCell className='text-right'>
-                                                    {(model.node.currentModelVersion &&
-                                                        model.node.currentModelVersion
-                                                            .numericVersion) ||
-                                                        0}
-                                                </TableCell>
-                                                <TableCell className='text-right'>
-                                                    {model.node.createdBy.userName}
-                                                </TableCell>
-                                                <TableCell className='text-right'>
-                                                    {model.node.dateModified}
-                                                </TableCell>
-                                                <TableCell className='text-right'>
-                                                    <Dropdown
-                                                        menuButton={
-                                                            <EllipsisHorizontalIcon className='h-6 w-6' />
-                                                        }
-                                                    >
-                                                        <DropdownItems>
-                                                            <DropdownItem>
-                                                                <a
-                                                                    href={`/dashboard/models/${model.node.modelId}/edit`}
-                                                                >
-                                                                    Edit
-                                                                </a>
-                                                            </DropdownItem>
-                                                            <DropdownItem>
-                                                                <button
-                                                                    onClick={() => {
-                                                                        setSelectedModel({
-                                                                            modelId:
-                                                                                model.node.modelId,
-                                                                            modelName:
-                                                                                model.node
-                                                                                    .modelName,
-                                                                        });
-                                                                        setArchiveModalOpen(true);
-                                                                    }}
-                                                                >
-                                                                    Archive
-                                                                </button>
-                                                            </DropdownItem>
-                                                            <Divider />
-                                                            <DropdownItem>
-                                                                <span className='text-indigo-600 font-semibold'>
-                                                                    Publish
-                                                                </span>
-                                                            </DropdownItem>
-                                                        </DropdownItems>
-                                                    </Dropdown>
-                                                </TableCell>
-                                            </TableRow>
-                                        ))}
-                                </TableBody>
-                            </Table>
-                            <CardFooter>
-                                <div className='flex items-center justify-between'>
-                                    {/* Dummy values */}
-                                    <div />
-                                    <div className='flex items-center gap-x-3'>
-                                        <Button
-                                            variant='secondary'
-                                            disabled={hasPreviousPage}
-                                            size='lg'
-                                            onClick={() => {
-                                                setContinuationTokens(
-                                                    continuationTokens.filter(
-                                                        (_, idx) =>
-                                                            idx !== continuationTokens.length - 1,
-                                                    ),
-                                                );
-                                                fetchMore({
-                                                    variables: {
-                                                        after: continuationTokens[
-                                                            continuationTokens.length - 1
-                                                        ],
-                                                    },
-                                                });
-                                            }}
-                                        >
-                                            Previous
-                                        </Button>
-                                        <Button
-                                            variant='secondary'
-                                            disabled={hasNextPage}
-                                            size='lg'
-                                            onClick={() =>
-                                                fetchMore({
-                                                    variables: {
-                                                        after: continuationTokens[
-                                                            continuationTokens.length - 1
-                                                        ],
-                                                    },
-                                                })
-                                            }
-                                        >
-                                            Next
-                                        </Button>
-                                    </div>
-                                </div>
-                            </CardFooter>
-                        </Card>
                     ) : (
-                        <BarLoader color='#4f46e5' width='250px' />
+                        <BarLoader color='#2563eb' width='250px' />
                     )}
                 </div>
             </div>


### PR DESCRIPTION
Working on some refactoring while working on some of the GH issues just for some housekeeping.

Decent amount of file changes, but it's mostly just moving stuff around so the main page component is no longer 300+ lines long.

Essentially, here's the structure:
- `api`: Any graphql queries specific to the page.
- `atoms`: Holds `jotai` atoms for any state specific to the page. The choice of `jotai` is personal preference. Technically it's more performant than `useContext` and just passing `useState` because it doesn't re-render the entire tree.
- `components`: Components that are group logically that make up the page. Not reusable, just page specific so that the main page component is smaller in size and easier to sift through.

Here's what the **final** design looks like, barring any additions to the page such as deployment information and any project / team metadata we want to include:

<img width="1280" alt="image" src="https://github.com/dstk-labs/dstk-web/assets/77359138/115e4b10-2bfc-4325-a4ee-b7de46c6a734">
