### PR TITLE
Add Basic Logout Functionality

### DIFF
--- a/src/atoms/jwt.ts
+++ b/src/atoms/jwt.ts
@@ -1,3 +1,3 @@
 import { atomWithStorage } from 'jotai/utils';
 
-export const jwtAtom = atomWithStorage('token', '');
+export const jwtAtom = atomWithStorage<string | null>('token', null);

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -1,5 +1,23 @@
+import { useSetAtom } from 'jotai';
+import { RESET } from 'jotai/utils';
+import { useNavigate } from 'react-router-dom';
+
+import { jwtAtom } from '@/atoms';
+import { apolloClient } from '@/lib';
+
 export const useAuth = () => {
     const token = localStorage.getItem('token');
 
     return !!token;
+};
+
+export const useLogout = () => {
+    const navigate = useNavigate();
+    const setToken = useSetAtom(jwtAtom);
+
+    return () => {
+        setToken(RESET);
+        apolloClient.resetStore();
+        navigate('/login');
+    };
 };

--- a/src/lib/apolloClient.ts
+++ b/src/lib/apolloClient.ts
@@ -1,0 +1,21 @@
+import { ApolloClient, createHttpLink, InMemoryCache } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+
+const httpLink = createHttpLink({
+    uri: 'http://localhost:4000',
+});
+
+const authLink = setContext((_, { headers }) => {
+    const token = localStorage.getItem('token');
+    return {
+        headers: {
+            ...headers,
+            authorization: token ? `Bearer ${JSON.parse(token)}` : '',
+        },
+    };
+});
+
+export const apolloClient = new ApolloClient({
+    link: authLink.concat(httpLink),
+    cache: new InMemoryCache(),
+});

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './apolloClient';
+export * from './cn';

--- a/src/providers/ApolloProvider.tsx
+++ b/src/providers/ApolloProvider.tsx
@@ -1,34 +1,11 @@
-import {
-    ApolloClient,
-    ApolloProvider as Provider,
-    createHttpLink,
-    InMemoryCache,
-} from '@apollo/client';
-import { setContext } from '@apollo/client/link/context';
+import { ApolloProvider as Provider } from '@apollo/client';
 
-const httpLink = createHttpLink({
-    uri: 'http://localhost:4000',
-});
-
-const authLink = setContext((_, { headers }) => {
-    const token = localStorage.getItem('token');
-    return {
-        headers: {
-            ...headers,
-            authorization: token ? `Bearer ${JSON.parse(token)}` : '',
-        },
-    };
-});
-
-const client = new ApolloClient({
-    link: authLink.concat(httpLink),
-    cache: new InMemoryCache(),
-});
+import { apolloClient } from '@/lib/apolloClient';
 
 type ApolloProviderProps = {
     children: React.ReactNode;
 };
 
 export const ApolloProvider = ({ children }: ApolloProviderProps) => {
-    return <Provider client={client}>{children}</Provider>;
+    return <Provider client={apolloClient}>{children}</Provider>;
 };

--- a/src/routes/home/index.tsx
+++ b/src/routes/home/index.tsx
@@ -1,3 +1,8 @@
+import { useLogout } from '@/hooks';
+import { Button } from '@/components/ui';
+
 export const Home = () => {
-    return <div>Hi!</div>;
+    const logout = useLogout();
+    // TODO: Just here until we get to User UI Stuff
+    return <Button onClick={logout}>Logout</Button>;
 };


### PR DESCRIPTION
Ref #15 

This PR adds a hook to let a user sign out manually. When the hook is called, three things happen:
1. The jwt token is removed from storage.
2. The authorization headers from the Apollo Client are removed.
3. The user is automatically sent back to the login page. It is worth pointing out that I used the `useNavigate` hook to accomplish this, but calling any type of action that refreshes the page will work since we have the public and private route components implemented.

The following adjustments were also made:
- The jwt token was originally being instantiated as `''`. I have changed it to instantiate as `null` because I do not want the token to be kept in local storage as an empty string, I want to yeet it from existence when the user logs out.
- It is good practice to clear the apollo client cache / store on logout. This method is exposed from the apollo client config so I put that into its own config file so that I can easily use it in both the `ApolloProvider` component and the `useLogout` hook.