### PR TITLE
Add Reusable Form Components

### DIFF
--- a/src/components/form/FieldWrapper.tsx
+++ b/src/components/form/FieldWrapper.tsx
@@ -1,0 +1,22 @@
+import type { FieldError } from 'react-hook-form';
+
+import { Label } from '../ui';
+
+export type FieldWrapperProps = {
+    error?: FieldError;
+    label?: string;
+} & React.LabelHTMLAttributes<HTMLLabelElement>;
+
+export type FieldPassThroughProps = Pick<FieldWrapperProps, 'error' | 'label'>;
+
+export const FieldWrapper = ({ children, className, error, label }: FieldWrapperProps) => {
+    return (
+        <div className='flex flex-col gap-3'>
+            <div className='flex flex-col gap-2'>
+                <Label className={className}>{label}</Label>
+                <div>{children}</div>
+            </div>
+            {error?.message && <p className='text-sm text-red-500'>{error.message}</p>}
+        </div>
+    );
+};

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -1,0 +1,38 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+    useForm,
+    type FieldValues,
+    type SubmitHandler,
+    type UseFormProps,
+    type UseFormReturn,
+} from 'react-hook-form';
+import { ZodType, ZodTypeDef } from 'zod';
+
+export type FormProps<TFormValues extends FieldValues, Schema> = {
+    children: (methods: UseFormReturn<TFormValues>) => React.ReactNode;
+    className?: string;
+    id?: string;
+    onSubmit: SubmitHandler<TFormValues>;
+    options?: UseFormProps<TFormValues>;
+    schema?: Schema;
+};
+
+export const Form = <
+    TFormValues extends Record<string, unknown> = Record<string, unknown>,
+    Schema extends ZodType<unknown, ZodTypeDef, unknown> = ZodType<unknown, ZodTypeDef, unknown>,
+>({
+    children,
+    className,
+    id,
+    onSubmit,
+    options,
+    schema,
+}: FormProps<TFormValues, Schema>) => {
+    const methods = useForm<TFormValues>({ ...options, resolver: schema && zodResolver(schema) });
+
+    return (
+        <form className={className} id={id} onSubmit={methods.handleSubmit(onSubmit)}>
+            {children(methods)}
+        </form>
+    );
+};

--- a/src/components/form/InputField.tsx
+++ b/src/components/form/InputField.tsx
@@ -1,0 +1,31 @@
+import type { UseFormRegisterReturn } from 'react-hook-form';
+
+import { Input, type InputProps } from '../ui';
+
+import { FieldWrapper, type FieldPassThroughProps } from './FieldWrapper';
+
+export type InputFieldProps = {
+    registration: Partial<UseFormRegisterReturn>;
+} & FieldPassThroughProps &
+    InputProps;
+
+export const InputField = ({
+    className,
+    error,
+    label,
+    registration,
+    type,
+    ...props
+}: InputFieldProps) => {
+    return (
+        <FieldWrapper label={label} error={error}>
+            <Input
+                className={className}
+                type={type}
+                variant={error ? 'error' : 'default'}
+                {...registration}
+                {...props}
+            />
+        </FieldWrapper>
+    );
+};

--- a/src/components/form/SelectField.tsx
+++ b/src/components/form/SelectField.tsx
@@ -1,0 +1,45 @@
+import type { UseFormRegisterReturn } from 'react-hook-form';
+
+import { Select, type SelectProps } from '../ui';
+
+import { FieldWrapper, type FieldPassThroughProps } from './FieldWrapper';
+
+type Option = {
+    id: string;
+    label: string;
+    value: string | number;
+};
+
+export type SelectFieldProps = {
+    options: Option[];
+    registration: Partial<UseFormRegisterReturn>;
+} & FieldPassThroughProps &
+    SelectProps;
+
+export const SelectField = ({
+    className,
+    defaultValue,
+    error,
+    label,
+    options,
+    registration,
+    ...props
+}: SelectFieldProps) => {
+    return (
+        <FieldWrapper label={label} error={error}>
+            <Select
+                className={className}
+                defaultValue={defaultValue}
+                variant={error ? 'error' : 'primary'}
+                {...registration}
+                {...props}
+            >
+                {options.map((option) => (
+                    <option key={option.id} value={option.value.toString()}>
+                        {option.label}
+                    </option>
+                ))}
+            </Select>
+        </FieldWrapper>
+    );
+};

--- a/src/components/form/TextAreaField.tsx
+++ b/src/components/form/TextAreaField.tsx
@@ -1,0 +1,24 @@
+import type { UseFormRegisterReturn } from 'react-hook-form';
+
+import { TextArea, type TextAreaProps } from '../ui';
+
+import { FieldWrapper, type FieldPassThroughProps } from './FieldWrapper';
+
+type TextAreaFieldProps = {
+    registration: Partial<UseFormRegisterReturn>;
+} & FieldPassThroughProps &
+    TextAreaProps;
+
+export const TextAreaField = ({
+    className,
+    error,
+    label,
+    registration,
+    ...props
+}: TextAreaFieldProps) => {
+    return (
+        <FieldWrapper label={label} error={error}>
+            <TextArea className={className} {...registration} {...props} />
+        </FieldWrapper>
+    );
+};

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,0 +1,5 @@
+export * from './FieldWrapper';
+export * from './Form';
+export * from './InputField';
+export * from './SelectField';
+export * from './TextAreaField';

--- a/src/components/ui/label/Label.tsx
+++ b/src/components/ui/label/Label.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@/lib/cn';
+import { cn } from '@/lib';
 
 export type LabelProps = {
     children: React.ReactNode;
@@ -6,10 +6,7 @@ export type LabelProps = {
 
 export const Label = ({ children, className, ...props }: LabelProps) => {
     return (
-        <label
-            className={cn('block text-sm font-medium leading-6 text-gray-900', className)}
-            {...props}
-        >
+        <label className={cn('block text-sm text-gray-500', className)} {...props}>
             {children}
         </label>
     );

--- a/src/components/ui/text-area/TextArea.tsx
+++ b/src/components/ui/text-area/TextArea.tsx
@@ -1,15 +1,36 @@
 import { forwardRef } from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
 
-type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+import { cn } from '@/lib';
 
-export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(({ ...props }, ref) => {
-    return (
-        <textarea
-            className='block w-full rounded-md border-0 py-1.5 px-3 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6'
-            ref={ref}
-            {...props}
-        />
-    );
-});
+const textAreaVariants = cva(
+    'block w-full rounded-lg border bg-white text-gray-700 placeholder-gray-400/70 text-sm shadow-sm px-4 py-2.5 focus:ring focus:outline-none focus:ring-opacity-40 disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500',
+    {
+        variants: {
+            variant: {
+                primary: 'border-gray-200 focus:border-blue-400 focus:ring-blue-300',
+                error: 'border-red-400 focus:border-red-400 focus:ring-red-300',
+            },
+        },
+        defaultVariants: {
+            variant: 'primary',
+        },
+    },
+);
+
+export type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> &
+    VariantProps<typeof textAreaVariants>;
+
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+    ({ className, variant, ...props }, ref) => {
+        return (
+            <textarea
+                className={cn(textAreaVariants({ variant, className }))}
+                ref={ref}
+                {...props}
+            />
+        );
+    },
+);
 
 TextArea.displayName = 'TextArea';


### PR DESCRIPTION
Just adding in some components that can be reused on form submissions. It basically just requires that all forms have a `zod` schema and `onSubmit` function. Also lets us pass error messages and other react-hook-form goodies to any child components of the form.