### PR TITLE
Add Wireframe for Model Version Details Page

### DIFF
--- a/src/routes/model-version-details/api/getModelVersion.ts
+++ b/src/routes/model-version-details/api/getModelVersion.ts
@@ -1,0 +1,38 @@
+import { gql, useQuery, type TypedDocumentNode } from '@apollo/client';
+
+import { useNotificationStore } from '@/stores';
+import type { GetMLModelVersion } from '@/types/MLModelVersion';
+
+const GET_MODEL_VERSION: TypedDocumentNode<GetMLModelVersion> = gql`
+    query GetMLModelVersion($modelVersionId: String!) {
+        getMLModelVersion(modelVersionId: $modelVersionId) {
+            modelId {
+                dateModified
+                modelName
+            }
+            description
+            modelVersionId
+            numericVersion
+            createdBy {
+                userName
+            }
+            dateCreated
+        }
+    }
+`;
+
+export const useGetMLModelVersion = (modelVersionId: string) => {
+    const { addNotification } = useNotificationStore();
+
+    return useQuery(GET_MODEL_VERSION, {
+        variables: {
+            modelVersionId: modelVersionId,
+        },
+        onError: (error) =>
+            addNotification({
+                type: 'error',
+                title: 'Error',
+                children: error.message,
+            }),
+    });
+};

--- a/src/routes/model-version-details/api/index.ts
+++ b/src/routes/model-version-details/api/index.ts
@@ -1,0 +1,1 @@
+export * from './getModelVersion';

--- a/src/routes/model-version-details/components/MLVersionDetailsHeader.tsx
+++ b/src/routes/model-version-details/components/MLVersionDetailsHeader.tsx
@@ -1,0 +1,37 @@
+import { PlusCircleIcon } from '@heroicons/react/24/outline';
+import { useNavigate } from 'react-router-dom';
+
+import { BreadcrumbItem, Breadcrumbs, Button } from '@/components/ui';
+import { MLModelVersion } from '@/types/MLModelVersion';
+
+type ModelVersionDetailsHeaderProps = {
+    mlModelVersion: MLModelVersion;
+};
+
+export const ModelVersionDetailsHeader = ({ mlModelVersion }: ModelVersionDetailsHeaderProps) => {
+    const { modelId, modelVersionId, numericVersion } = mlModelVersion;
+    const navigate = useNavigate();
+
+    return (
+        <header className='flex flex-col gap-6'>
+            <div>
+                <Breadcrumbs>
+                    <BreadcrumbItem href='/dashboard/home'>Dashboard</BreadcrumbItem>
+                    <BreadcrumbItem href='/dashboard/models'>Models</BreadcrumbItem>
+                    <BreadcrumbItem href={`/dashboard/models/${modelId.modelId}}`}>
+                        {modelId.modelName}
+                    </BreadcrumbItem>
+                    <BreadcrumbItem href={`/dashboard/models/${modelId.modelId}/${modelVersionId}`}>
+                        v{numericVersion}
+                    </BreadcrumbItem>
+                </Breadcrumbs>
+            </div>
+            <div className='flex items-center justify-between'>
+                <h2 className='text-2xl font-medium text-gray-700 sm:text-3xl'>Version Details</h2>
+                <Button onClick={() => navigate('/dashboard/models/create')} icon={PlusCircleIcon}>
+                    Add Files
+                </Button>
+            </div>
+        </header>
+    );
+};

--- a/src/routes/model-version-details/components/MLVersionMetadata.tsx
+++ b/src/routes/model-version-details/components/MLVersionMetadata.tsx
@@ -1,0 +1,50 @@
+import { Card, CardBody, Label } from '@/components/ui';
+
+import type { MLModelVersion } from '@/types/MLModelVersion';
+
+type MLVersionMetadataProps = {
+    mlModelVersion: MLModelVersion;
+};
+
+export const MLVersionMetadata = ({ mlModelVersion }: MLVersionMetadataProps) => {
+    const { createdBy, description, modelId, numericVersion } = mlModelVersion;
+
+    return (
+        <Card>
+            <CardBody>
+                <div className='flex flex-col gap-4'>
+                    <h2 className='text-xl text-gray-700'>Model Metadata</h2>
+                    <div className='grid grid-cols-2 gap-4'>
+                        <div>
+                            <Label>Model Name</Label>
+                            <p className='text-gray-700'>{modelId.modelName}</p>
+                        </div>
+                        <div>
+                            <Label>Version Number</Label>
+                            <p className='text-gray-700'>v{numericVersion}</p>
+                        </div>
+                        <div>
+                            <Label>Description</Label>
+                            <p className='text-gray-700'>{description}</p>
+                        </div>
+                        <div>
+                            <Label>Created By</Label>
+                            <div className='flex gap-0.5 text-blue-600'>
+                                <div>@</div>
+                                <div className='hover:underline hover:cursor-pointer'>
+                                    {createdBy.userName}
+                                </div>
+                            </div>
+                        </div>
+                        <div>
+                            <Label>Last Updated</Label>
+                            <p className='text-gray-700'>
+                                {new Date(parseInt(modelId.dateModified)).toLocaleDateString()}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </CardBody>
+        </Card>
+    );
+};

--- a/src/routes/model-version-details/components/index.ts
+++ b/src/routes/model-version-details/components/index.ts
@@ -1,0 +1,2 @@
+export * from './MLVersionDetailsHeader';
+export * from './MLVersionMetadata';

--- a/src/routes/model-version-details/index.tsx
+++ b/src/routes/model-version-details/index.tsx
@@ -1,3 +1,32 @@
+import { useLocation } from 'react-router-dom';
+import { BarLoader } from 'react-spinners';
+
+import { useGetMLModelVersion } from './api';
+import { MLVersionMetadata, ModelVersionDetailsHeader } from './components';
+
 export const ModelVersionDetails = () => {
-    return <div>Suh dude. Here is the page w/ all of the model version goodness.</div>;
+    const { pathname } = useLocation();
+    const versionId = pathname.split('/')[pathname.split('/').length - 1];
+
+    const { data, loading, error } = useGetMLModelVersion(versionId);
+
+    if (loading) {
+        return <BarLoader color='#2563eb' width='250px' />;
+    }
+
+    if (error) {
+        return <p>Error loading model information.</p>;
+    }
+
+    if (data) {
+        return (
+            <div className='w-full flex flex-col gap-12'>
+                <ModelVersionDetailsHeader mlModelVersion={data.getMLModelVersion} />
+                <MLVersionMetadata mlModelVersion={data.getMLModelVersion} />
+                {/* TODO: File Explorer */}
+            </div>
+        );
+    } else {
+        return null;
+    }
 };

--- a/src/routes/model-version/index.tsx
+++ b/src/routes/model-version/index.tsx
@@ -99,11 +99,16 @@ export const ModelVersion = () => {
                         {mlVersionData &&
                             mlVersionData.listMLModelVersions &&
                             mlVersionData.listMLModelVersions.map((mlVersion) => (
-                                <TableRow key={mlVersion.modelVersionId}>
-                                    <TableCell
-                                        className='hover:text-gray-800 hover:cursor-pointer'
-                                        onClick={() => handleCopy(mlVersion.modelVersionId)}
-                                    >
+                                <TableRow
+                                    className='hover:bg-gray-50 hover:cursor-pointer'
+                                    onClick={() =>
+                                        navigate(
+                                            `/dashboard/models/${modelId}/${mlVersion.modelVersionId}`,
+                                        )
+                                    }
+                                    key={mlVersion.modelVersionId}
+                                >
+                                    <TableCell>
                                         <Tooltip
                                             isVisible={
                                                 !isTooltipHidden &&
@@ -111,11 +116,16 @@ export const ModelVersion = () => {
                                             }
                                             message='Copied!'
                                         >
-                                            <div className='flex items-center gap-1'>
+                                            <div className='flex items-center gap-1 hover:text-gray-800'>
                                                 <div>
                                                     {mlVersion.modelVersionId.substring(0, 8)}...
                                                 </div>
-                                                <ClipboardIcon className='h-3 w-3 shrink-0 hover:text-gray-800 hover:cursor-pointer' />
+                                                <ClipboardIcon
+                                                    className='h-3 w-3 shrink-0 hover:text-gray-800 hover:cursor-pointer'
+                                                    onClick={() =>
+                                                        handleCopy(mlVersion.modelVersionId)
+                                                    }
+                                                />
                                             </div>
                                         </Tooltip>
                                     </TableCell>

--- a/src/types/MLModelVersion.ts
+++ b/src/types/MLModelVersion.ts
@@ -14,6 +14,10 @@ export type MLModelVersion = {
     s3Prefix: string;
 };
 
+export type GetMLModelVersion = {
+    getMLModelVersion: MLModelVersion;
+};
+
 export type MLModelVersionList = {
     listMLModelVersions: MLModelVersion[];
 };


### PR DESCRIPTION
This PR adds some UI for the Model Version Detail Page. Specifically the header and metadata card portions. Next would be integrating the S3 file explorer and uploading pieces.

<img width="1025" alt="image" src="https://github.com/dstk-labs/dstk-web/assets/77359138/65b681c0-5a49-4b72-a2ff-1b99518185b0">
