### PR TITLE
Add Wireframe for User Settings Page

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -24,7 +24,7 @@ const navigation = [
         links: [
             {
                 name: 'Settings',
-                href: '/settings',
+                href: '/settings/user-settings',
                 icon: <Cog6ToothIcon />,
             },
         ],

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -24,7 +24,7 @@ const navigation = [
         links: [
             {
                 name: 'Settings',
-                href: '/settings/user-settings',
+                href: '/settings',
                 icon: <Cog6ToothIcon />,
             },
         ],

--- a/src/components/settings/UserNavigation.tsx
+++ b/src/components/settings/UserNavigation.tsx
@@ -1,0 +1,34 @@
+import { useLocation } from 'react-router-dom';
+
+import { cn } from '@/lib';
+
+const TABS = [
+    { name: 'Settings', href: '/settings/user-settings' },
+    { name: 'Teams', href: '/settings/teams' },
+    { name: 'Storage Providers', href: '/settings/storage-providers' },
+];
+
+export const UserNavigation = () => {
+    const { pathname } = useLocation();
+
+    return (
+        <div className='border-b border-gray-200'>
+            <nav className='flex gap-8'>
+                {TABS.map((tab) => (
+                    <a
+                        key={tab.name}
+                        href={tab.href}
+                        className={cn(
+                            'whitespace-nowrap border-b-2 py-4 px-1 text-sm font-medium',
+                            tab.href === pathname
+                                ? 'border-blue-500 text-blue-600'
+                                : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
+                        )}
+                    >
+                        {tab.name}
+                    </a>
+                ))}
+            </nav>
+        </div>
+    );
+};

--- a/src/components/settings/UserNavigation.tsx
+++ b/src/components/settings/UserNavigation.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib';
 
 const TABS = [
     { name: 'Settings', href: '/settings/user-settings' },
+    { name: 'API Keys', href: '/settings/api-keys' },
     { name: 'Teams', href: '/settings/teams' },
     { name: 'Storage Providers', href: '/settings/storage-providers' },
 ];

--- a/src/components/settings/UserNavigation.tsx
+++ b/src/components/settings/UserNavigation.tsx
@@ -3,9 +3,8 @@ import { useLocation } from 'react-router-dom';
 import { cn } from '@/lib';
 
 const TABS = [
-    { name: 'Settings', href: '/settings/user-settings' },
+    { name: 'User Settings', href: '/settings' },
     { name: 'API Keys', href: '/settings/api-keys' },
-    { name: 'Teams', href: '/settings/teams' },
     { name: 'Storage Providers', href: '/settings/storage-providers' },
 ];
 

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,0 +1,1 @@
+export * from './UserNavigation';

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -13,6 +13,7 @@ import {
     ModelVersionDetails,
     Register,
     UploadFiles,
+    UserSettings,
 } from '@/routes';
 
 export const RouterProvider = () => {
@@ -39,7 +40,6 @@ export const RouterProvider = () => {
             children: [
                 {
                     element: <DashboardLayout />,
-                    path: '/dashboard',
                     children: [
                         {
                             path: '/dashboard/home',
@@ -72,6 +72,10 @@ export const RouterProvider = () => {
                         {
                             path: '/dashboard/models/:modelId/:versionId/upload',
                             element: <UploadFiles />,
+                        },
+                        {
+                            path: '/settings/user-settings',
+                            element: <UserSettings />,
                         },
                     ],
                 },

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -74,7 +74,7 @@ export const RouterProvider = () => {
                             element: <UploadFiles />,
                         },
                         {
-                            path: '/settings/user-settings',
+                            path: '/settings',
                             element: <UserSettings />,
                         },
                     ],

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,3 +8,4 @@ export * from './model-version';
 export * from './model-version-details';
 export * from './register';
 export * from './upload-files';
+export * from './user-settings';

--- a/src/routes/user-settings/index.tsx
+++ b/src/routes/user-settings/index.tsx
@@ -1,0 +1,3 @@
+export const UserSettings = () => {
+    return <div>Welcome to the User Settings Page!</div>;
+};

--- a/src/routes/user-settings/index.tsx
+++ b/src/routes/user-settings/index.tsx
@@ -3,7 +3,7 @@ import { BreadcrumbItem, Breadcrumbs } from '@/components/ui';
 
 export const UserSettings = () => {
     return (
-        <div className='w-full flex flex-col gap-8'>
+        <div className='w-full flex flex-col gap-6'>
             <header className='flex flex-col gap-3'>
                 <Breadcrumbs>
                     <BreadcrumbItem href='/dashboard'>Dashboard</BreadcrumbItem>

--- a/src/routes/user-settings/index.tsx
+++ b/src/routes/user-settings/index.tsx
@@ -1,3 +1,22 @@
+import { UserNavigation } from '@/components/settings';
+import { BreadcrumbItem, Breadcrumbs } from '@/components/ui';
+
 export const UserSettings = () => {
-    return <div>Welcome to the User Settings Page!</div>;
+    return (
+        <div className='w-full flex flex-col gap-8'>
+            <header className='flex flex-col gap-3'>
+                <Breadcrumbs>
+                    <BreadcrumbItem href='/dashboard'>Dashboard</BreadcrumbItem>
+                    <BreadcrumbItem href='/dashboard/settings/user-settings'>
+                        Settings
+                    </BreadcrumbItem>
+                    <BreadcrumbItem href='/dashboard/settings/user-settings'>
+                        User Settings
+                    </BreadcrumbItem>
+                </Breadcrumbs>
+                <h1 className='text-2xl font-medium text-gray-700 sm:text-3xl'>User Settings</h1>
+            </header>
+            <UserNavigation />
+        </div>
+    );
 };

--- a/src/routes/user-settings/index.tsx
+++ b/src/routes/user-settings/index.tsx
@@ -6,13 +6,7 @@ export const UserSettings = () => {
         <div className='w-full flex flex-col gap-6'>
             <header className='flex flex-col gap-3'>
                 <Breadcrumbs>
-                    <BreadcrumbItem href='/dashboard'>Dashboard</BreadcrumbItem>
-                    <BreadcrumbItem href='/dashboard/settings/user-settings'>
-                        Settings
-                    </BreadcrumbItem>
-                    <BreadcrumbItem href='/dashboard/settings/user-settings'>
-                        User Settings
-                    </BreadcrumbItem>
+                    <BreadcrumbItem href='/settings'>Settings</BreadcrumbItem>
                 </Breadcrumbs>
                 <h1 className='text-2xl font-medium text-gray-700 sm:text-3xl'>User Settings</h1>
             </header>


### PR DESCRIPTION
Ref #16 

Going to start implementing the API methods for Storage Providers, Teams, Projects, API Keys, etc.

I'm thinking that a "Projects" Section should live in the sidebar, but Storage Provider, Team Management, API Key stuff, etc should live within the User Settings realm:

<img width="1016" alt="image" src="https://github.com/dstk-labs/dstk-web/assets/77359138/dc50c099-dd50-4934-866f-75af55b617fc">
