### PR TITLE
Add API Key Features

### DIFF
--- a/src/components/ui/card/Card.tsx
+++ b/src/components/ui/card/Card.tsx
@@ -6,13 +6,7 @@ export type CardProps = {
 
 export const Card = ({ children, className, ...props }: CardProps) => {
     return (
-        <div
-            className={cn(
-                'divide-y divide-gray-200 overflow-hidden rounded-lg bg-white shadow',
-                className,
-            )}
-            {...props}
-        >
+        <div className={cn('overflow-hidden rounded-lg bg-white shadow', className)} {...props}>
             {children}
         </div>
     );

--- a/src/components/ui/card/CardHeader.tsx
+++ b/src/components/ui/card/CardHeader.tsx
@@ -6,7 +6,7 @@ export type CardHeaderProps = {
 
 export const CardHeader = ({ children, className, ...props }: CardHeaderProps) => {
     return (
-        <div className={cn('px-4 py-2 sm:px-6', className)} {...props}>
+        <div className={cn('px-4 pt-6 pb-4', className)} {...props}>
             {children}
         </div>
     );

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter, RouterProvider as Router } from 'react-router-dom'
 import { PrivateRoute, PublicRoute } from '@/components/auth';
 import { DashboardLayout } from '@/components/layout';
 import {
+    APIKeys,
     CreateModel,
     CreateModelVersion,
     EditModel,
@@ -76,6 +77,10 @@ export const RouterProvider = () => {
                         {
                             path: '/settings',
                             element: <UserSettings />,
+                        },
+                        {
+                            path: '/settings/api-keys',
+                            element: <APIKeys />,
                         },
                     ],
                 },

--- a/src/routes/api-keys/api/archiveAPIKey.ts
+++ b/src/routes/api-keys/api/archiveAPIKey.ts
@@ -1,0 +1,26 @@
+import { gql, useMutation, type TypedDocumentNode } from '@apollo/client';
+
+import { useNotificationStore } from '@/stores';
+import type { ArchiveAPIKey } from '@/types/APIKey';
+
+const ARCHIVE_API_KEY: TypedDocumentNode<ArchiveAPIKey> = gql`
+    mutation ArchiveApiKey($apiKeyId: String!) {
+        archiveApiKey(apiKeyId: $apiKeyId) {
+            apiKeyId
+        }
+    }
+`;
+
+export const useArchiveAPIKey = () => {
+    const { addNotification } = useNotificationStore();
+
+    return useMutation(ARCHIVE_API_KEY, {
+        refetchQueries: ['ListApiKeys'],
+        onError: (error) =>
+            addNotification({
+                type: 'error',
+                title: 'Error',
+                children: error.message,
+            }),
+    });
+};

--- a/src/routes/api-keys/api/createAPIKey.ts
+++ b/src/routes/api-keys/api/createAPIKey.ts
@@ -1,0 +1,31 @@
+import { gql, useMutation, type TypedDocumentNode } from '@apollo/client';
+
+import { useNotificationStore } from '@/stores';
+import type { CreateAPIKey } from '@/types/APIKey';
+
+const CREATE_API_KEY: TypedDocumentNode<CreateAPIKey> = gql`
+    mutation CreateApiKey {
+        createApiKey {
+            apiKeyId
+        }
+    }
+`;
+
+export const useCreateAPIKey = () => {
+    const { addNotification } = useNotificationStore();
+
+    return useMutation(CREATE_API_KEY, {
+        refetchQueries: ['ListApiKeys'],
+        onCompleted: () =>
+            addNotification({
+                type: 'success',
+                title: 'Successfully provisioned new API key.',
+            }),
+        onError: (error) =>
+            addNotification({
+                type: 'error',
+                title: 'Error',
+                children: error.message,
+            }),
+    });
+};

--- a/src/routes/api-keys/api/index.ts
+++ b/src/routes/api-keys/api/index.ts
@@ -1,0 +1,3 @@
+export * from './archiveAPIKey';
+export * from './createAPIKey';
+export * from './listAPIKeys';

--- a/src/routes/api-keys/api/listAPIKeys.ts
+++ b/src/routes/api-keys/api/listAPIKeys.ts
@@ -1,0 +1,28 @@
+import { gql, useQuery, type TypedDocumentNode } from '@apollo/client';
+
+import { useNotificationStore } from '@/stores';
+import type { APIKeyList } from '@/types/APIKey';
+
+const LIST_API_KEYS: TypedDocumentNode<APIKeyList> = gql`
+    query ListApiKeys {
+        listApiKeys {
+            apiKey
+            apiKeyId
+            dateCreated
+            isArchived
+        }
+    }
+`;
+
+export const useListAPIKeys = () => {
+    const { addNotification } = useNotificationStore();
+
+    return useQuery(LIST_API_KEYS, {
+        onError: (error) =>
+            addNotification({
+                type: 'error',
+                title: 'Error',
+                children: error.message,
+            }),
+    });
+};

--- a/src/routes/api-keys/atoms/apiKeyIdAtom.ts
+++ b/src/routes/api-keys/atoms/apiKeyIdAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const apiKeyIdAtom = atom('');

--- a/src/routes/api-keys/atoms/archiveModelOpenAtom.ts
+++ b/src/routes/api-keys/atoms/archiveModelOpenAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const archiveModalOpenAtom = atom(false);

--- a/src/routes/api-keys/atoms/index.ts
+++ b/src/routes/api-keys/atoms/index.ts
@@ -1,0 +1,2 @@
+export * from './archiveModelOpenAtom';
+export * from './apiKeyIdAtom';

--- a/src/routes/api-keys/components/APIKeysCard.tsx
+++ b/src/routes/api-keys/components/APIKeysCard.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { ArchiveBoxIcon, ClipboardIcon } from '@heroicons/react/24/outline';
+import { useSetAtom } from 'jotai';
+
+import { Button, Card, CardBody, CardHeader, Tooltip } from '@/components/ui';
+import { APIKey } from '@/types/APIKey';
+
+import { apiKeyIdAtom, archiveModalOpenAtom } from '../atoms';
+import { useCreateAPIKey } from '../api';
+
+type APIKeysTableProps = {
+    apiKeys: APIKey[];
+};
+
+export const APIKeysCard = ({ apiKeys }: APIKeysTableProps) => {
+    const setApiKeyId = useSetAtom(apiKeyIdAtom);
+    const setArchiveModalOpen = useSetAtom(archiveModalOpenAtom);
+
+    const [selectedApiKey, setSelectedApiKey] = useState('');
+    const [isTooltipHidden, setIsTooltipHidden] = useState(true);
+
+    const [createAPIKey, { loading }] = useCreateAPIKey();
+
+    const handleArchiveClick = (apiKeyId: string) => {
+        setApiKeyId(apiKeyId);
+        setArchiveModalOpen(true);
+    };
+
+    const handleCopy = (apiKey: string) => {
+        if (isTooltipHidden) {
+            setIsTooltipHidden(false);
+            setSelectedApiKey(apiKey);
+            navigator.clipboard.writeText(apiKey);
+
+            setTimeout(() => {
+                setIsTooltipHidden(false);
+                setSelectedApiKey('');
+            }, 750);
+        }
+    };
+
+    return (
+        <Card>
+            <CardHeader>
+                <div className='flex items-center justify-between'>
+                    <h2 className='text-xl font-medium leading-none tracking-tight'>API Keys</h2>
+                    <Button onClick={() => createAPIKey()} loading={loading}>
+                        Create New Key
+                    </Button>
+                </div>
+            </CardHeader>
+            <CardBody>
+                <div className='flex flex-col gap-4'>
+                    {apiKeys.map((apiKey) => (
+                        <div key={apiKey.apiKeyId} className='flex items-center justify-between'>
+                            <div className='flex flex-col'>
+                                <p className='text-sm font-medium'>{apiKey.apiKey}</p>
+                                <p className='text-sm text-gray-500'>
+                                    Created: {new Date(parseInt(apiKey.dateCreated)).toDateString()}
+                                </p>
+                            </div>
+                            <div className='flex items-center gap-2'>
+                                <Tooltip
+                                    isVisible={!isTooltipHidden && apiKey.apiKey === selectedApiKey}
+                                    message='Copied!'
+                                >
+                                    <Button
+                                        icon={ClipboardIcon}
+                                        onClick={() => handleCopy(apiKey.apiKey)}
+                                        variant='ghost'
+                                    />
+                                </Tooltip>
+                                <Button
+                                    icon={ArchiveBoxIcon}
+                                    onClick={() => handleArchiveClick(apiKey.apiKeyId)}
+                                    variant='ghost'
+                                />
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </CardBody>
+        </Card>
+    );
+};

--- a/src/routes/api-keys/components/APIKeysHeader.tsx
+++ b/src/routes/api-keys/components/APIKeysHeader.tsx
@@ -1,0 +1,13 @@
+import { BreadcrumbItem, Breadcrumbs } from '@/components/ui';
+
+export const APIKeysHeader = () => {
+    return (
+        <header className='flex flex-col gap-3'>
+            <Breadcrumbs>
+                <BreadcrumbItem href='/settings'>Settings</BreadcrumbItem>
+                <BreadcrumbItem href='/settings/api-keys'>API Keys</BreadcrumbItem>
+            </Breadcrumbs>
+            <h1 className='text-2xl font-medium text-gray-700 sm:text-3xl'>Model Registry</h1>
+        </header>
+    );
+};

--- a/src/routes/api-keys/components/APIKeysHeader.tsx
+++ b/src/routes/api-keys/components/APIKeysHeader.tsx
@@ -7,7 +7,7 @@ export const APIKeysHeader = () => {
                 <BreadcrumbItem href='/settings'>Settings</BreadcrumbItem>
                 <BreadcrumbItem href='/settings/api-keys'>API Keys</BreadcrumbItem>
             </Breadcrumbs>
-            <h1 className='text-2xl font-medium text-gray-700 sm:text-3xl'>Model Registry</h1>
+            <h1 className='text-2xl font-medium text-gray-700 sm:text-3xl'>API Keys</h1>
         </header>
     );
 };

--- a/src/routes/api-keys/components/ArchiveAPIKeyModal.tsx
+++ b/src/routes/api-keys/components/ArchiveAPIKeyModal.tsx
@@ -1,0 +1,59 @@
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { useAtom, useAtomValue } from 'jotai';
+
+import {
+    Button,
+    Modal,
+    ModalBody,
+    ModalContents,
+    ModalFooter,
+    ModalIcon,
+    ModalTitle,
+} from '@/components/ui';
+
+import { apiKeyIdAtom, archiveModalOpenAtom } from '../atoms';
+import { useArchiveAPIKey } from '../api';
+
+export const ArchiveModal = () => {
+    const apiKeyId = useAtomValue(apiKeyIdAtom);
+    const [archiveModalOpen, setArchiveModalOpen] = useAtom(archiveModalOpenAtom);
+
+    const [archiveAPIKey, { loading }] = useArchiveAPIKey();
+
+    const handleArchive = () => {
+        archiveAPIKey({
+            variables: {
+                apiKeyId: apiKeyId,
+            },
+            onCompleted: () => handleClose(),
+        });
+    };
+
+    const handleClose = () => setArchiveModalOpen(false);
+
+    return (
+        <Modal isOpen={archiveModalOpen} onClose={handleClose}>
+            <ModalContents>
+                <ModalIcon>
+                    <ExclamationTriangleIcon className='h-6 w-6 text-red-600' />
+                </ModalIcon>
+                <ModalBody>
+                    <ModalTitle>Archive API Key</ModalTitle>
+                    <div className='pt-2'>
+                        <p className='text-sm text-gray-500'>
+                            Are you sure you want to proceed with this action?
+                        </p>
+                    </div>
+                </ModalBody>
+            </ModalContents>
+            <ModalFooter>
+                <Button onClick={() => handleArchive()} loading={loading} variant='destructive'>
+                    Archive
+                </Button>
+                <Button variant='secondary' onClick={handleClose}>
+                    Cancel
+                </Button>
+            </ModalFooter>
+        </Modal>
+    );
+};

--- a/src/routes/api-keys/components/NoAPIKeysFound.tsx
+++ b/src/routes/api-keys/components/NoAPIKeysFound.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@/components/ui';
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { useCreateAPIKey } from '../api';
+
+export const NoAPIKeysFound = () => {
+    const [createAPIKey, { loading }] = useCreateAPIKey();
+
+    return (
+        <div className='flex items-center text-center border rounded-lg h-96'>
+            <div className='flex flex-col items-center gap-3 w-full max-w-sm px-4 mx-auto'>
+                <div className='p-3 mx-auto text-blue-500 bg-blue-100 rounded-full'>
+                    <MagnifyingGlassIcon className='w-6 h-6' />
+                </div>
+                <h3 className='text-lg text-gray-800'>No Api Keys Found</h3>
+                <Button className='max-w-fit' loading={loading} onClick={() => createAPIKey()}>
+                    Create API Key
+                </Button>
+            </div>
+        </div>
+    );
+};

--- a/src/routes/api-keys/components/index.ts
+++ b/src/routes/api-keys/components/index.ts
@@ -1,0 +1,4 @@
+export * from './APIKeysCard';
+export * from './APIKeysHeader';
+export * from './ArchiveAPIKeyModal';
+export * from './NoAPIKeysFound';

--- a/src/routes/api-keys/index.tsx
+++ b/src/routes/api-keys/index.tsx
@@ -1,0 +1,3 @@
+export const APIKeys = () => {
+    return <div>Hi! We can do stuff w/ your API Keys here!</div>;
+};

--- a/src/routes/api-keys/index.tsx
+++ b/src/routes/api-keys/index.tsx
@@ -1,3 +1,37 @@
+import { BarLoader } from 'react-spinners';
+
+import { UserNavigation } from '@/components/settings';
+
+import { useListAPIKeys } from './api';
+import { APIKeysHeader, APIKeysCard, ArchiveModal, NoAPIKeysFound } from './components';
+
 export const APIKeys = () => {
-    return <div>Hi! We can do stuff w/ your API Keys here!</div>;
+    const { data, loading, error } = useListAPIKeys();
+
+    if (error) {
+        return <p>Failed loading the API keys.</p>;
+    }
+
+    if (loading) {
+        return <BarLoader color='#2563eb' width='250px' />;
+    }
+
+    if (data && data.listApiKeys) {
+        return (
+            <>
+                <div className='w-full flex flex-col gap-6'>
+                    <APIKeysHeader />
+                    <UserNavigation />
+                    {data.listApiKeys.length === 0 ? (
+                        <NoAPIKeysFound />
+                    ) : (
+                        <APIKeysCard apiKeys={data.listApiKeys} />
+                    )}
+                </div>
+                <ArchiveModal />
+            </>
+        );
+    } else {
+        return null;
+    }
 };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,3 +1,4 @@
+export * from './api-keys';
 export * from './create-model';
 export * from './create-model-version';
 export * from './edit-model';

--- a/src/types/APIKey.ts
+++ b/src/types/APIKey.ts
@@ -1,0 +1,19 @@
+export type APIKey = {
+    apiKey: string;
+    apiKeyId: string;
+    dateCreated: string;
+    isArchived: boolean;
+    userId: string;
+};
+
+export type APIKeyList = {
+    listApiKeys: APIKey[];
+};
+
+export type CreateAPIKey = {
+    createAPIKey: APIKey;
+};
+
+export type ArchiveAPIKey = {
+    archiveApiKey: APIKey;
+};


### PR DESCRIPTION
Ref #16

Adds in an API Key Management Page to the user settings section. The page:
- Allows users to provision new API Keys
- Allows users to archive existing API Keys
- Shows all non-archived API keys and the date they were created.
- Allows users to copy their API keys.

Not super concerned with making the UX super pretty at the moment, but for now here is what it looks like:

<img width="514" alt="image" src="https://github.com/dstk-labs/dstk-web/assets/77359138/bb24a881-7bce-4dc1-bdb0-f87302c84409">
