### PR TITLE
Add File Explorer

### DIFF
--- a/src/routes/model-version-details/api/index.ts
+++ b/src/routes/model-version-details/api/index.ts
@@ -1,1 +1,2 @@
 export * from './getModelVersion';
+export * from './listObjects';

--- a/src/routes/model-version-details/api/listObjects.ts
+++ b/src/routes/model-version-details/api/listObjects.ts
@@ -1,5 +1,5 @@
 import { gql, useQuery, type TypedDocumentNode } from '@apollo/client';
-import { useAtomValue } from 'jotai';
+import { useAtom } from 'jotai';
 
 import type { StorageProviderObjectList } from '@/types/StorageProvider';
 import { useNotificationStore } from '@/stores';
@@ -38,15 +38,21 @@ const LIST_OBJECTS_FOR_MODEL_VERSION: TypedDocumentNode<StorageProviderObjectLis
 
 export const useListStorageProviderObjects = (modelVersionId: string) => {
     const { addNotification } = useNotificationStore();
-    const inputs = useAtomValue(listObjectsPaginationAtom);
+    const [inputs, setInputs] = useAtom(listObjectsPaginationAtom);
 
     return useQuery(LIST_OBJECTS_FOR_MODEL_VERSION, {
         variables: {
             after: inputs.continuationTokens.at(-1),
             first: inputs.first,
             modelVersionId: modelVersionId,
-            prefix: inputs.prefix,
+            prefix: inputs.prefixes.at(-1),
         },
+        onCompleted: (data) =>
+            setInputs((values) => ({
+                ...values,
+                hasPreviousPage: data.listObjectsForModelVersion.pageInfo.hasPreviousPage,
+                hasNextPage: data.listObjectsForModelVersion.pageInfo.hasNextPage,
+            })),
         onError: (error) =>
             addNotification({
                 type: 'error',

--- a/src/routes/model-version-details/api/listObjects.ts
+++ b/src/routes/model-version-details/api/listObjects.ts
@@ -1,0 +1,57 @@
+import { gql, useQuery, type TypedDocumentNode } from '@apollo/client';
+import { useAtomValue } from 'jotai';
+
+import type { StorageProviderObjectList } from '@/types/StorageProvider';
+import { useNotificationStore } from '@/stores';
+
+import { listObjectsPaginationAtom } from '../atoms';
+
+const LIST_OBJECTS_FOR_MODEL_VERSION: TypedDocumentNode<StorageProviderObjectList> = gql`
+    query ListObjectsForModelVersion(
+        $modelVersionId: String!
+        $after: String
+        $first: Limit!
+        $prefix: String
+    ) {
+        listObjectsForModelVersion(
+            modelVersionId: $modelVersionId
+            after: $after
+            first: $first
+            prefix: $prefix
+        ) {
+            edges {
+                cursor
+                node {
+                    lastModified
+                    name
+                    size
+                }
+            }
+            pageInfo {
+                continuationToken
+                hasNextPage
+                hasPreviousPage
+            }
+        }
+    }
+`;
+
+export const useListStorageProviderObjects = (modelVersionId: string) => {
+    const { addNotification } = useNotificationStore();
+    const inputs = useAtomValue(listObjectsPaginationAtom);
+
+    return useQuery(LIST_OBJECTS_FOR_MODEL_VERSION, {
+        variables: {
+            after: inputs.continuationTokens.at(-1),
+            first: inputs.first,
+            modelVersionId: modelVersionId,
+            prefix: inputs.prefix,
+        },
+        onError: (error) =>
+            addNotification({
+                type: 'error',
+                title: 'Error',
+                children: error.message,
+            }),
+    });
+};

--- a/src/routes/model-version-details/atoms/index.ts
+++ b/src/routes/model-version-details/atoms/index.ts
@@ -1,0 +1,1 @@
+export * from './listObjectsPaginationAtom';

--- a/src/routes/model-version-details/atoms/listObjectsPaginationAtom.ts
+++ b/src/routes/model-version-details/atoms/listObjectsPaginationAtom.ts
@@ -1,0 +1,18 @@
+import { atom } from 'jotai';
+import type { Limit } from '@/types/Limit';
+
+type ListObjectsPaginationInput = {
+    first: Limit;
+    continuationTokens: (string | undefined)[];
+    hasPreviousPage: boolean;
+    hasNextPage: boolean;
+    prefix?: string;
+};
+
+export const listObjectsPaginationAtom = atom<ListObjectsPaginationInput>({
+    first: 10,
+    continuationTokens: [undefined],
+    hasPreviousPage: false,
+    hasNextPage: false,
+    prefix: undefined,
+});

--- a/src/routes/model-version-details/atoms/listObjectsPaginationAtom.ts
+++ b/src/routes/model-version-details/atoms/listObjectsPaginationAtom.ts
@@ -10,7 +10,7 @@ type ListObjectsPaginationInput = {
 };
 
 export const listObjectsPaginationAtom = atom<ListObjectsPaginationInput>({
-    first: 10,
+    first: 25,
     continuationTokens: [undefined],
     hasPreviousPage: false,
     hasNextPage: false,

--- a/src/routes/model-version-details/atoms/listObjectsPaginationAtom.ts
+++ b/src/routes/model-version-details/atoms/listObjectsPaginationAtom.ts
@@ -6,13 +6,13 @@ type ListObjectsPaginationInput = {
     continuationTokens: (string | undefined)[];
     hasPreviousPage: boolean;
     hasNextPage: boolean;
-    prefix?: string;
+    prefixes: (string | undefined)[];
 };
 
 export const listObjectsPaginationAtom = atom<ListObjectsPaginationInput>({
-    first: 25,
+    first: 10,
     continuationTokens: [undefined],
     hasPreviousPage: false,
     hasNextPage: false,
-    prefix: undefined,
+    prefixes: [undefined],
 });

--- a/src/routes/model-version-details/components/FileExplorer.tsx
+++ b/src/routes/model-version-details/components/FileExplorer.tsx
@@ -1,0 +1,41 @@
+import {
+    Card,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeaderCell,
+    TableRow,
+} from '@/components/ui';
+import type { StorageProviderObjectList } from '@/types/StorageProvider';
+
+type FileExplorerProps = {
+    objects: StorageProviderObjectList;
+};
+
+export const FileExplorer = ({ objects }: FileExplorerProps) => {
+    return (
+        <Card>
+            <Table>
+                <TableHead>
+                    <TableRow>
+                        <TableHeaderCell>Type</TableHeaderCell>
+                        <TableHeaderCell>Name</TableHeaderCell>
+                        <TableHeaderCell>Size (kb)</TableHeaderCell>
+                        <TableHeaderCell>Last Modified</TableHeaderCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {objects.listObjectsForModelVersion.edges.map((edge) => (
+                        <TableRow key={edge.node.name}>
+                            <TableCell>Hi</TableCell>
+                            <TableCell>{edge.node.name}</TableCell>
+                            <TableCell>{edge.node.size}</TableCell>
+                            <TableCell>{edge.node.lastModified}</TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </Card>
+    );
+};

--- a/src/routes/model-version-details/components/FileExplorer.tsx
+++ b/src/routes/model-version-details/components/FileExplorer.tsx
@@ -10,13 +10,15 @@ import {
     TableRow,
 } from '@/components/ui';
 import type { StorageProviderObjectList } from '@/types/StorageProvider';
-import { isDirectory } from '../lib';
+import { createDirectory } from '../lib';
 
 type FileExplorerProps = {
     objects: StorageProviderObjectList;
 };
 
 export const FileExplorer = ({ objects }: FileExplorerProps) => {
+    const files = createDirectory(objects);
+
     return (
         <Card>
             <Table>
@@ -29,20 +31,28 @@ export const FileExplorer = ({ objects }: FileExplorerProps) => {
                     </TableRow>
                 </TableHead>
                 <TableBody>
-                    {objects.listObjectsForModelVersion.edges.map((edge) => (
-                        <TableRow key={edge.node.name}>
-                            <TableCell>
-                                {isDirectory(edge.node.name) ? (
+                    <>
+                        {files.directories.map((directory) => (
+                            <TableRow key={directory.name}>
+                                <TableCell>
                                     <FolderIcon className='w-5 h-5' />
-                                ) : (
+                                </TableCell>
+                                <TableCell>{directory.name.split('/')[0]}</TableCell>
+                                <TableCell>{directory.size}</TableCell>
+                                <TableCell>{directory.lastModified}</TableCell>
+                            </TableRow>
+                        ))}
+                        {files.files.map((file) => (
+                            <TableRow key={file.name}>
+                                <TableCell>
                                     <DocumentIcon className='w-5 h-5' />
-                                )}
-                            </TableCell>
-                            <TableCell>{edge.node.name}</TableCell>
-                            <TableCell>{edge.node.size}</TableCell>
-                            <TableCell>{edge.node.lastModified}</TableCell>
-                        </TableRow>
-                    ))}
+                                </TableCell>
+                                <TableCell>{file.name}</TableCell>
+                                <TableCell>{file.size}</TableCell>
+                                <TableCell>{file.lastModified}</TableCell>
+                            </TableRow>
+                        ))}
+                    </>
                 </TableBody>
             </Table>
         </Card>

--- a/src/routes/model-version-details/components/FileExplorer.tsx
+++ b/src/routes/model-version-details/components/FileExplorer.tsx
@@ -1,4 +1,5 @@
 import { DocumentIcon, FolderIcon } from '@heroicons/react/24/outline';
+import { useAtom } from 'jotai';
 
 import {
     Card,
@@ -10,6 +11,8 @@ import {
     TableRow,
 } from '@/components/ui';
 import type { StorageProviderObjectList } from '@/types/StorageProvider';
+
+import { listObjectsPaginationAtom } from '../atoms';
 import { createDirectory } from '../lib';
 
 type FileExplorerProps = {
@@ -17,6 +20,7 @@ type FileExplorerProps = {
 };
 
 export const FileExplorer = ({ objects }: FileExplorerProps) => {
+    const [inputs, setInputs] = useAtom(listObjectsPaginationAtom);
     const files = createDirectory(objects);
 
     return (
@@ -32,24 +36,58 @@ export const FileExplorer = ({ objects }: FileExplorerProps) => {
                 </TableHead>
                 <TableBody>
                     <>
+                        {inputs.prefixes.length > 1 ? (
+                            <TableRow
+                                className='hover:bg-gray-100 hover:cursor-pointer'
+                                onClick={() =>
+                                    setInputs((values) => ({
+                                        ...values,
+                                        prefixes: values.prefixes.slice(0, -1),
+                                    }))
+                                }
+                            >
+                                <TableCell>
+                                    <FolderIcon className='w-5 h-5' />
+                                </TableCell>
+                                <TableCell>..</TableCell>
+                                <TableCell> </TableCell>
+                                <TableCell> </TableCell>
+                            </TableRow>
+                        ) : null}
                         {files.directories.map((directory) => (
-                            <TableRow key={directory.name}>
+                            <TableRow
+                                className='hover:bg-gray-100 hover:cursor-pointer'
+                                onClick={() =>
+                                    setInputs((values) => ({
+                                        ...values,
+                                        prefixes: [
+                                            ...values.prefixes,
+                                            directory.name.split('/')[0],
+                                        ],
+                                    }))
+                                }
+                                key={directory.name}
+                            >
                                 <TableCell>
                                     <FolderIcon className='w-5 h-5' />
                                 </TableCell>
                                 <TableCell>{directory.name.split('/')[0]}</TableCell>
                                 <TableCell>{directory.size}</TableCell>
-                                <TableCell>{directory.lastModified}</TableCell>
+                                <TableCell>
+                                    {new Date(directory.lastModified).toLocaleDateString()}
+                                </TableCell>
                             </TableRow>
                         ))}
                         {files.files.map((file) => (
-                            <TableRow key={file.name}>
+                            <TableRow className='hover:bg-gray-100' key={file.name}>
                                 <TableCell>
                                     <DocumentIcon className='w-5 h-5' />
                                 </TableCell>
                                 <TableCell>{file.name}</TableCell>
                                 <TableCell>{file.size}</TableCell>
-                                <TableCell>{file.lastModified}</TableCell>
+                                <TableCell>
+                                    {new Date(file.lastModified).toLocaleDateString()}
+                                </TableCell>
                             </TableRow>
                         ))}
                     </>

--- a/src/routes/model-version-details/components/FileExplorer.tsx
+++ b/src/routes/model-version-details/components/FileExplorer.tsx
@@ -1,3 +1,5 @@
+import { DocumentIcon, FolderIcon } from '@heroicons/react/24/outline';
+
 import {
     Card,
     Table,
@@ -8,6 +10,7 @@ import {
     TableRow,
 } from '@/components/ui';
 import type { StorageProviderObjectList } from '@/types/StorageProvider';
+import { isDirectory } from '../lib';
 
 type FileExplorerProps = {
     objects: StorageProviderObjectList;
@@ -28,7 +31,13 @@ export const FileExplorer = ({ objects }: FileExplorerProps) => {
                 <TableBody>
                     {objects.listObjectsForModelVersion.edges.map((edge) => (
                         <TableRow key={edge.node.name}>
-                            <TableCell>Hi</TableCell>
+                            <TableCell>
+                                {isDirectory(edge.node.name) ? (
+                                    <FolderIcon className='w-5 h-5' />
+                                ) : (
+                                    <DocumentIcon className='w-5 h-5' />
+                                )}
+                            </TableCell>
                             <TableCell>{edge.node.name}</TableCell>
                             <TableCell>{edge.node.size}</TableCell>
                             <TableCell>{edge.node.lastModified}</TableCell>

--- a/src/routes/model-version-details/components/FileExplorerPagination.tsx
+++ b/src/routes/model-version-details/components/FileExplorerPagination.tsx
@@ -1,0 +1,44 @@
+import { useAtom } from 'jotai';
+
+import { Button } from '@/components/ui';
+
+import { listObjectsPaginationAtom } from '../atoms';
+
+type FileExplorerPaginationProps = {
+    continuationToken: string;
+};
+
+export const FileExplorerPagination = ({ continuationToken }: FileExplorerPaginationProps) => {
+    const [inputs, setInputs] = useAtom(listObjectsPaginationAtom);
+
+    const handlePrevPage = () =>
+        setInputs((values) => ({
+            ...values,
+            continuationTokens: values.continuationTokens.slice(0, -1),
+        }));
+
+    const handleNextPage = () =>
+        setInputs((values) => ({
+            ...values,
+            continuationTokens: [...values.continuationTokens, continuationToken],
+        }));
+
+    return (
+        <div className='flex items-center justify-end gap-x-3'>
+            <Button
+                variant='secondary'
+                disabled={!inputs.hasPreviousPage}
+                onClick={() => handlePrevPage()}
+            >
+                Previous
+            </Button>
+            <Button
+                variant='secondary'
+                disabled={!inputs.hasNextPage}
+                onClick={() => handleNextPage()}
+            >
+                Next
+            </Button>
+        </div>
+    );
+};

--- a/src/routes/model-version-details/components/index.ts
+++ b/src/routes/model-version-details/components/index.ts
@@ -1,2 +1,3 @@
+export * from './FileExplorer';
 export * from './MLVersionDetailsHeader';
 export * from './MLVersionMetadata';

--- a/src/routes/model-version-details/components/index.ts
+++ b/src/routes/model-version-details/components/index.ts
@@ -1,3 +1,4 @@
 export * from './FileExplorer';
+export * from './FileExplorerPagination';
 export * from './MLVersionDetailsHeader';
 export * from './MLVersionMetadata';

--- a/src/routes/model-version-details/index.tsx
+++ b/src/routes/model-version-details/index.tsx
@@ -2,7 +2,12 @@ import { useParams } from 'react-router-dom';
 import { BarLoader } from 'react-spinners';
 
 import { useGetMLModelVersion, useListStorageProviderObjects } from './api';
-import { FileExplorer, MLVersionMetadata, ModelVersionDetailsHeader } from './components';
+import {
+    FileExplorer,
+    FileExplorerPagination,
+    MLVersionMetadata,
+    ModelVersionDetailsHeader,
+} from './components';
 
 export const ModelVersionDetails = () => {
     const { versionId } = useParams();
@@ -32,6 +37,11 @@ export const ModelVersionDetails = () => {
                 <ModelVersionDetailsHeader mlModelVersion={model.getMLModelVersion} />
                 <MLVersionMetadata mlModelVersion={model.getMLModelVersion} />
                 <FileExplorer objects={objects} />
+                <FileExplorerPagination
+                    continuationToken={
+                        objects.listObjectsForModelVersion.pageInfo.continuationToken
+                    }
+                />
             </div>
         );
     } else {

--- a/src/routes/model-version-details/index.tsx
+++ b/src/routes/model-version-details/index.tsx
@@ -2,7 +2,7 @@ import { useLocation } from 'react-router-dom';
 import { BarLoader } from 'react-spinners';
 
 import { useGetMLModelVersion } from './api';
-import { MLVersionMetadata, ModelVersionDetailsHeader } from './components';
+import { FileExplorer, MLVersionMetadata, ModelVersionDetailsHeader } from './components';
 
 export const ModelVersionDetails = () => {
     const { pathname } = useLocation();
@@ -23,7 +23,7 @@ export const ModelVersionDetails = () => {
             <div className='w-full flex flex-col gap-12'>
                 <ModelVersionDetailsHeader mlModelVersion={data.getMLModelVersion} />
                 <MLVersionMetadata mlModelVersion={data.getMLModelVersion} />
-                {/* TODO: File Explorer */}
+                <FileExplorer />
             </div>
         );
     } else {

--- a/src/routes/model-version-details/index.tsx
+++ b/src/routes/model-version-details/index.tsx
@@ -1,29 +1,37 @@
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { BarLoader } from 'react-spinners';
 
-import { useGetMLModelVersion } from './api';
+import { useGetMLModelVersion, useListStorageProviderObjects } from './api';
 import { FileExplorer, MLVersionMetadata, ModelVersionDetailsHeader } from './components';
 
 export const ModelVersionDetails = () => {
-    const { pathname } = useLocation();
-    const versionId = pathname.split('/')[pathname.split('/').length - 1];
+    const { versionId } = useParams();
 
-    const { data, loading, error } = useGetMLModelVersion(versionId);
+    const {
+        data: model,
+        loading: modelLoading,
+        error: modelError,
+    } = useGetMLModelVersion(versionId || '');
+    const {
+        data: objects,
+        loading: objectsLoading,
+        error: objectsError,
+    } = useListStorageProviderObjects(versionId || '');
 
-    if (loading) {
+    if (modelLoading || objectsLoading) {
         return <BarLoader color='#2563eb' width='250px' />;
     }
 
-    if (error) {
+    if (modelError || objectsError) {
         return <p>Error loading model information.</p>;
     }
 
-    if (data) {
+    if (model && model.getMLModelVersion && objects && objects.listObjectsForModelVersion) {
         return (
             <div className='w-full flex flex-col gap-12'>
-                <ModelVersionDetailsHeader mlModelVersion={data.getMLModelVersion} />
-                <MLVersionMetadata mlModelVersion={data.getMLModelVersion} />
-                <FileExplorer />
+                <ModelVersionDetailsHeader mlModelVersion={model.getMLModelVersion} />
+                <MLVersionMetadata mlModelVersion={model.getMLModelVersion} />
+                <FileExplorer objects={objects} />
             </div>
         );
     } else {

--- a/src/routes/model-version-details/lib/fileBrowser.ts
+++ b/src/routes/model-version-details/lib/fileBrowser.ts
@@ -1,1 +1,31 @@
+import type { StorageProviderObject, StorageProviderObjectList } from '@/types/StorageProvider';
+
 export const isDirectory = (filePath: string): boolean => filePath.split('/').length > 1;
+
+export const createDirectory = (objects: StorageProviderObjectList) => {
+    const edges = objects.listObjectsForModelVersion.edges;
+
+    // Get All Directories and Files Returned from query
+    const directories: StorageProviderObject[] = [];
+    const files: StorageProviderObject[] = [];
+
+    // Add directory only if it doesn't exist
+    for (const edge of edges) {
+        if (isDirectory(edge.node.name)) {
+            if (!directories.includes(edge.node)) {
+                directories.push(edge.node);
+            }
+        }
+    }
+
+    for (const edge of edges) {
+        if (!isDirectory(edge.node.name)) {
+            files.push(edge.node);
+        }
+    }
+
+    return {
+        directories: directories,
+        files: files,
+    };
+};

--- a/src/routes/model-version-details/lib/fileBrowser.ts
+++ b/src/routes/model-version-details/lib/fileBrowser.ts
@@ -1,0 +1,1 @@
+export const isDirectory = (filePath: string): boolean => filePath.split('/').length > 1;

--- a/src/routes/model-version-details/lib/index.ts
+++ b/src/routes/model-version-details/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './fileBrowser';

--- a/src/types/StorageProvider.ts
+++ b/src/types/StorageProvider.ts
@@ -1,3 +1,4 @@
+import type { Edge, PageInfo } from './Cursor';
 import { User } from './User';
 
 export type StorageProvider = {
@@ -15,6 +16,19 @@ export type StorageProvider = {
     isArchvied: boolean;
 };
 
+export type StorageProviderObject = {
+    lastModified: string;
+    name: string;
+    size: number;
+};
+
 export type StorageProviderList = {
     listStorageProviders: StorageProvider[];
+};
+
+export type StorageProviderObjectList = {
+    listObjectsForModelVersion: {
+        edges: Edge<StorageProviderObject>[];
+        pageInfo: PageInfo;
+    };
 };


### PR DESCRIPTION
Ref #2

Adds a file explorer component to the model version details page. Did not use a tree structure to mimic a directory tree because we are not pulling all available directories. Will come back to this when I tweak all of the UI and UX and add in some type of indication as to what depth the user is at within the file system.

Workflow:
  - Load files from root directory.
  - Split files and folders
    - Users can click on folders
  - If a folder is clicked, use the folder name as a prefix to the S3 API and show the files within that folder.
  - If not at the root directory, a table row is displayed with a `..` to signify going up one depth in the file structure.

#### Root Level
<img width="997" alt="image" src="https://github.com/dstk-labs/dstk-web/assets/77359138/a8649950-560b-4968-808b-4a139adcc132">

#### test-folder-01 Level
<img width="997" alt="image" src="https://github.com/dstk-labs/dstk-web/assets/77359138/fee010f8-1698-436d-922e-0b41f28696a5">
