### PR TITLE
Add Breadcrumbs to Dashboard Layout

### DIFF
--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -1,7 +1,14 @@
 import { Cog6ToothIcon, HomeIcon, SquaresPlusIcon, UsersIcon } from '@heroicons/react/24/outline';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useMatches, type UIMatch } from 'react-router-dom';
 
-import { Sidebar, SidebarContent, SidebarLink, SidebarSection } from '../ui';
+import {
+    BreadcrumbItem,
+    Breadcrumbs,
+    Sidebar,
+    SidebarContent,
+    SidebarLink,
+    SidebarSection,
+} from '../ui';
 
 const navigation = [
     {
@@ -42,6 +49,16 @@ const navigation = [
 ];
 
 export const DashboardLayout = () => {
+    // Am I a frontend engineer yet?
+    const matches = useMatches() as UIMatch<unknown, { crumb: (data?: unknown) => string }>[];
+
+    const crumbs = matches
+        .filter((match) => Boolean(match.handle))
+        .map((match) => ({
+            href: match.pathname,
+            label: match.handle.crumb(),
+        }));
+
     return (
         <div className='flex min-h-screen'>
             <Sidebar>
@@ -60,9 +77,20 @@ export const DashboardLayout = () => {
                     ))}
                 </SidebarContent>
             </Sidebar>
-            <main className='flex-grow px-5 py-9 bg-gray-100 md:py-8'>
-                <Outlet />
-            </main>
+            <section className='flex grow flex-col'>
+                <div className='w-full'>
+                    <Breadcrumbs>
+                        {crumbs.map((crumb) => (
+                            <BreadcrumbItem href={crumb.href} key={crumb.href}>
+                                {crumb.label}
+                            </BreadcrumbItem>
+                        ))}
+                    </Breadcrumbs>
+                </div>
+                <main className='flex-grow px-5 py-9 bg-gray-100 md:py-8'>
+                    <Outlet />
+                </main>
+            </section>
         </div>
     );
 };

--- a/src/providers/RouterProvider.tsx
+++ b/src/providers/RouterProvider.tsx
@@ -20,6 +20,8 @@ import {
     UploadFiles,
     UserSettings,
 } from '@/routes';
+import type { MLModelVersion } from '@/types/MLModelVersion';
+import type { Team } from '@/types/Team';
 
 export const RouterProvider = () => {
     const router = createBrowserRouter([
@@ -45,6 +47,9 @@ export const RouterProvider = () => {
             children: [
                 {
                     element: <DashboardLayout />,
+                    handle: {
+                        crumb: () => 'Home',
+                    },
                     children: [
                         {
                             path: '/dashboard/home',
@@ -52,55 +57,128 @@ export const RouterProvider = () => {
                         },
                         {
                             path: '/dashboard/models',
-                            element: <ModelRegistry />,
+                            handle: {
+                                crumb: () => 'Models',
+                            },
+                            children: [
+                                {
+                                    element: <ModelRegistry />,
+                                    index: true,
+                                },
+                                {
+                                    path: '/dashboard/models/create',
+                                    element: <CreateModel />,
+                                    handle: {
+                                        crumb: () => 'Create',
+                                    },
+                                },
+                                {
+                                    path: '/dashboard/models/:modelId',
+                                    handle: {
+                                        crumb: (data?: MLModelVersion) =>
+                                            (data && data.modelId.modelId) || 'Async is fun',
+                                    },
+                                    children: [
+                                        {
+                                            element: <ModelVersion />,
+                                            index: true,
+                                        },
+                                        {
+                                            path: '/dashboard/models/:modelId/edit',
+                                            element: <EditModel />,
+                                            handle: {
+                                                crumb: () => 'Edit',
+                                            },
+                                        },
+                                        {
+                                            path: '/dashboard/models/:modelId/create',
+                                            element: <CreateModelVersion />,
+                                            handle: {
+                                                crumb: () => 'Create',
+                                            },
+                                        },
+                                        {
+                                            path: '/dashboard/models/:modelId/:versionId',
+                                            handle: {
+                                                crumb: (data?: MLModelVersion) =>
+                                                    (data && `v${data.numericVersion}`) ||
+                                                    'Async is super duper fun',
+                                            },
+                                            children: [
+                                                {
+                                                    element: <ModelVersionDetails />,
+                                                    index: true,
+                                                },
+                                                {
+                                                    path: '/dashboard/models/:modelId/:versionId/upload',
+                                                    element: <UploadFiles />,
+                                                    handle: {
+                                                        crumb: () => 'Upload Files',
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                },
+                            ],
                         },
                         {
-                            path: '/dashboard/models/create',
-                            element: <CreateModel />,
+                            path: 'dashboard/teams',
+                            handle: {
+                                crumb: () => 'Teams',
+                            },
+                            children: [
+                                {
+                                    element: <Teams />,
+                                    index: true,
+                                },
+                                {
+                                    path: 'dashboard/teams/create',
+                                    element: <CreateTeam />,
+                                    handle: {
+                                        crumb: () => 'Create',
+                                    },
+                                },
+                                {
+                                    path: 'dashboard/teams/:teamId',
+                                    handle: {
+                                        crumb: (data?: Team) =>
+                                            (data && data.name) || 'BILLIE JEAN',
+                                    },
+                                    children: [
+                                        {
+                                            element: <TeamDetails />,
+                                            index: true,
+                                        },
+                                        {
+                                            path: 'dashboard/teams/:teamId/add-member',
+                                            element: <AddTeamMember />,
+                                            handle: {
+                                                crumb: () => 'Add Team Member',
+                                            },
+                                        },
+                                    ],
+                                },
+                            ],
                         },
                         {
-                            path: '/dashboard/models/:modelId',
-                            element: <ModelVersion />,
-                        },
-                        {
-                            path: '/dashboard/models/:modelId/edit',
-                            element: <EditModel />,
-                        },
-                        {
-                            path: '/dashboard/models/:modelId/create',
-                            element: <CreateModelVersion />,
-                        },
-                        {
-                            path: '/dashboard/models/:modelId/:versionId',
-                            element: <ModelVersionDetails />,
-                        },
-                        {
-                            path: '/dashboard/models/:modelId/:versionId/upload',
-                            element: <UploadFiles />,
-                        },
-                        {
-                            path: '/teams',
-                            element: <Teams />,
-                        },
-                        {
-                            path: '/teams/create',
-                            element: <CreateTeam />,
-                        },
-                        {
-                            path: '/teams/:teamId',
-                            element: <TeamDetails />,
-                        },
-                        {
-                            path: 'teams/:teamId/add-member',
-                            element: <AddTeamMember />,
-                        },
-                        {
-                            path: '/settings',
-                            element: <UserSettings />,
-                        },
-                        {
-                            path: '/settings/api-keys',
-                            element: <APIKeys />,
+                            path: 'dashboard/settings',
+                            handle: {
+                                crumb: () => 'Settings',
+                            },
+                            children: [
+                                {
+                                    element: <UserSettings />,
+                                    index: true,
+                                },
+                                {
+                                    path: 'dashboard/settings/api-keys',
+                                    element: <APIKeys />,
+                                    handle: {
+                                        crumb: () => 'API Keys',
+                                    },
+                                },
+                            ],
                         },
                     ],
                 },


### PR DESCRIPTION
So it turns out that `react-router-dom` has some fun powerful hooks that you can leverage (more on that in future PRs 😎)

This PR adds the breadcrumb nav components to the dashboard layout. Meaning that we no longer have to manually define them on every page. Their hierarchy and labels are populated automatically. In order for this to work I had to change up some of the routing defined in `RouterProvider` because `react-router-dom` does some unintuitive things when it comes to rendering children and sibling routes. Nothing earth-shattering to worry about though, it's the javascript equivalent of shuffling papers around. However, I am down to explain the quirkiness if needed.

This is done by leveraging the [`useMatches`](https://reactrouter.com/en/main/hooks/use-matches) hook. It is important to note that I did not remove the breadcrumbs manually defined on each page because:
1) Didn't want to slap you with a 40+ file change PR (or whatever the number would be).
2) I'll get to those.. sometime in the future.